### PR TITLE
chore: prove a permission shortfall fails before any job exists

### DIFF
--- a/.github/workflows/advisory.yml
+++ b/.github/workflows/advisory.yml
@@ -15,5 +15,4 @@ jobs:
   advisory:
     permissions:
       contents: read # the capability checks this tree out to lint it
-      pull-requests: write # the one comment it edits in place
     uses: $/.github/workflows/prek-advisory.yml


### PR DESCRIPTION
Throwaway. `pull-requests: write` removed from `advisory.yml`'s call so the startup failure can be observed. T075's one item no gate can prove. Closing straight after.