### PR TITLE
fix: send blob content as utf-8 rather than a base64 argument

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -150,13 +150,21 @@ jobs:
           PY
           uv lock
 
+          # `--rawfile`, never an argument: a base64 of the lockfile is far past the argument-length
+          # limit, and the blobs API takes UTF-8 directly, so there is nothing to encode.
           blob() {
-            jq -n --arg content "$(base64 -w0 < "$1")" '{content: $content, encoding: "base64"}' \
+            jq -n --rawfile content "$1" '{content: $content, encoding: "utf-8"}' \
               > "$RUNNER_TEMP/blob.json"
             gh api "repos/$GH_REPO/git/blobs" --input "$RUNNER_TEMP/blob.json" --jq .sha
           }
           manifest=$(blob pyproject.toml)
           lockfile=$(blob uv.lock)
+          for sha in "$manifest" "$lockfile"; do
+            case "$sha" in
+              ????????????????????????????????????????) ;;
+              *) echo "::error::a blob came back as '$sha' rather than a sha, so the tree would name nothing. The proposal was not written." >&2; exit 1 ;;
+            esac
+          done
 
           base=$(gh api "repos/$GH_REPO/git/commits/$COMMIT" --jq .tree.sha)
           jq -n --arg base "$base" --arg m "$manifest" --arg l "$lockfile" '{


### PR DESCRIPTION
## What changed

- fix: send blob content as utf-8 rather than a base64 argument

## Why?

The first real proposal run after merging #2 failed: `jq: Argument line too long`. The lockfile's
base64 exceeded the argument limit, so the blob sha came back empty and the tree creation returned 422.

## Blast radius

`release-proposal.yml` only. It has never successfully written a proposal, so nothing regresses.

## Verification

`mise run ci` green offline. The real proof is the next push to `main`, which runs this path.

## Docs

None — the change is transport, not contract.

## Commits

- fix: send blob content as utf-8 rather than a base64 argument

  The lockfile's base64 is past the argument-length limit, so jq died with
  "Argument list too long", the blob sha came back empty and the tree creation
  422'd. The blobs API takes UTF-8 directly and jq reads a file with --rawfile, so
  there is nothing to encode and no argument to overflow.

  A guard now rejects anything that is not a forty-character sha before a tree is
  built from it, because an empty sha names a valid-looking tree entry pointing at
  nothing.

