### PR TITLE
fix: let a routine merge decline quietly whatever the range holds

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,17 @@ once published — a wrong one cannot be deleted, only lived with.
 It refuses, always before any ref exists, when the run is not on your repository's own default branch;
 when the declared version is not a plain `N.N.N`; when that version is not ahead of the highest release
 across *every* compatibility line; when the range renders no notes; or when the range breaks your
-consumer surface while the version stays on a line that already has a release. A routine merge that
-simply did not bump the version declines with a notice instead of failing — your default branch should
-not redden for doing nothing wrong.
+consumer surface while the version stays on a line that already has a release.
+
+**A routine merge never reddens your default branch.** While the version has not been bumped past the
+highest release it is provisional, so nothing else about it can be judged yet — the run declines with a
+notice and releases nothing, whatever the range contains. Releasing is therefore what merging a version
+bump does, not something every merge attempts.
+
+The one thing that does redden it is a version that *has* been bumped and is wrong for its range: a
+break while the new version stays on a line that already has a release, which would force a ref your
+consumers pin across that break. That is asserted rather than provisional, so it fails however the run
+was reached.
 
 Prerequisites in the calling repository: `git-cliff` pinned in `mise.toml`, a `cliff.toml` mapping
 commit types to sections, a `[project].version` in `pyproject.toml`, and the surface declaration below.

--- a/actions/release-decisions/decisions.py
+++ b/actions/release-decisions/decisions.py
@@ -263,9 +263,14 @@ def decide(request: Request) -> Verdict:
         )
     if not found:
         return Verdict(True, NOTICE, f"every refusal passed for {request.version_text}")
-    if request.occasion == ROUTINE and [r.key for r in found] == [ALREADY_RELEASED]:
-        # A default branch must not redden for doing nothing wrong: a merge that did not bump the
-        # version is not a mistake. Every other refusal is a defect whichever event reached it.
+    if request.occasion == ROUTINE and ALREADY_RELEASED in [r.key for r in found]:
+        # A version that is not ahead of the highest release has not been bumped yet, which makes it
+        # provisional — so nothing below it can be assessed. A break "on a released line" then only says
+        # the bump has not happened, and a default branch must not redden for that.
+        #
+        # This softens only while the version is behind. A version that *is* ahead has been asserted by
+        # a merged change, so anything wrong with it is a real mistake and stays an error however the
+        # run was reached — including a break that would move a ref consumers pin.
         return Verdict(False, NOTICE, reported)
     return Verdict(False, ERROR, reported)
 

--- a/tests/test_release_decisions.py
+++ b/tests/test_release_decisions.py
@@ -317,3 +317,36 @@ def test_neither_verdict_is_reached_by_a_range_holding_neither() -> None:
 
 def test_one_break_anywhere_in_the_range_counts() -> None:
     assert range_verdicts(["docs: reword", "refactor!: move a call site"]) == (True, False)
+
+
+def test_a_routine_push_declines_quietly_even_when_the_range_breaks_something() -> None:
+    # The version is behind, so it has not been bumped yet; a break "on a released line" only restates
+    # that. Reddening the default branch here trains people to ignore a red default branch.
+    verdict = decide(
+        ADMITTED._replace(
+            occasion=ROUTINE, version_text="0.1.0", existing=((0, 1, 0),), breaking=True
+        )
+    )
+    assert verdict.proceed is False
+    assert verdict.severity == NOTICE
+
+
+def test_a_routine_push_declines_quietly_when_the_range_renders_no_notes_either() -> None:
+    verdict = decide(
+        ADMITTED._replace(occasion=ROUTINE, version_text="0.1.0", existing=((0, 1, 0),), notes="")
+    )
+    assert verdict.proceed is False
+    assert verdict.severity == NOTICE
+
+
+def test_a_bumped_version_that_breaks_its_own_released_line_is_an_error_on_any_occasion() -> None:
+    # The one this must not swallow. 0.1.5 is ahead of 0.1.0, so somebody asserted it — and releasing it
+    # would force `v0.1` across a break, which is the thing a moving ref exists to prevent.
+    for occasion in (ROUTINE, DELIBERATE):
+        verdict = decide(
+            ADMITTED._replace(
+                occasion=occasion, version_text="0.1.5", existing=((0, 1, 0),), breaking=True
+            )
+        )
+        assert verdict.proceed is False, occasion
+        assert verdict.severity == ERROR, occasion


### PR DESCRIPTION
## What changed

- fix: let a routine merge decline quietly whatever the range holds

## Why?

A merge carrying a breaking change reddened `main`. The routine-push softening matched the refusal set
exactly, and a breaking range trips two refusals rather than one, so it fell through to an error. A range
rendering no notes did the same.

## Blast radius

Nothing released, so no consumer can observe the old behaviour. It changes which runs are red: strictly
fewer, and only where red carried no information.

| manifest | occasion | range | run |
| --- | --- | --- | --- |
| not bumped | routine | anything | green, declines with a notice |
| bumped, breaks its own released line | any | breaking | **red** |
| bumped across the line | routine | breaking | green, releases |
| not bumped | deliberate | anything | red — you asked |

## Verification

79 tests offline. The table above was exercised end to end through the action's environment edge, not
just the pure functions.

## Docs

README's `release` section now states it: a routine merge never reddens the default branch, and the one
thing that does is a bumped version wrong for its range.

## Commits

- fix: let a routine merge decline quietly whatever the range holds

  The softening for a routine push matched the refusal set exactly, so a merge
  carrying a breaking change reddened the default branch: `already-released` and
  `breaks-a-released-line` both fired, the exact match failed, and it fell through
  to an error. The same happened to a merge whose range rendered no notes.

  Neither is a mistake. While the version is not ahead of the highest release it
  has not been bumped yet, which makes it provisional — a break "on a released
  line" then only restates that the bump has not happened. Reddening for it trains
  people to ignore a red default branch, which is the expensive habit.

  So `already-released` is now a stop rather than an exact match, the same shape
  the ladder already uses for a version that does not parse: nothing below a
  provisional version can be assessed.

  Loosening it further would have swallowed the case that has to stay loud. A
  version that *is* ahead was asserted by a merged change, so a break that would
  force a ref consumers pin across it fails on any occasion — routine included.
  Three tests pin that, one per shape.

