### PR TITLE
feat: measure an unreleased repository against 0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ when the declared version is not a plain `N.N.N`; when that version is not ahead
 across *every* compatibility line; when the range renders no notes; or when the range breaks your
 consumer surface while the version stays on a line that already has a release.
 
+**Nothing is released until the version says so.** A repository with no releases is measured against
+`0.0.0`, so a manifest sitting there is not ahead of anything and every merge declines. That is the hold
+for initial development: stay at `0.0.0` for as long as it takes, then bump when there is something worth
+publishing. Nothing else to remember, and nothing to switch off afterwards.
+
 **A routine merge never reddens your default branch.** While the version has not been bumped past the
 highest release it is provisional, so nothing else about it can be judged yet — the run declines with a
 notice and releases nothing, whatever the range contains. Releasing is therefore what merging a version

--- a/actions/release-decisions/decisions.py
+++ b/actions/release-decisions/decisions.py
@@ -14,6 +14,11 @@ Version = tuple[int, int, int]
 # move a ref consumers pin.
 FIRST_STABLE: Version = (1, 0, 0)
 
+# The baseline a repository with no releases is measured against, which is what makes this version
+# mean "not released yet": it is not ahead of itself, so every merge declines while it stands. A
+# repository can sit here for as long as it takes to have something worth publishing.
+UNRELEASED: Version = (0, 0, 0)
+
 # No leading zero, no pre-release, no build metadata, no leading `v`.
 VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
@@ -219,16 +224,21 @@ def refusals(request: Request) -> list[Refusal]:
         # Nothing below can be decided without a version, and a refusal derived from one that was
         # never read would name a comparison nobody made.
         return found
-    highest = max(request.existing, default=None)
-    if highest is not None and version <= highest:
-        found.append(
-            Refusal(
-                ALREADY_RELEASED,
+    highest = max(request.existing, default=UNRELEASED)
+    if version <= highest:
+        if request.existing:
+            behind = (
                 f"the declared version {format_version(version)} is not ahead of "
                 f"{format_version(highest)}, the highest release across every compatibility line. A "
-                "frozen line is left where it is rather than backported",
+                "frozen line is left where it is rather than backported"
             )
-        )
+        else:
+            behind = (
+                f"nothing has been released and the declared version is {format_version(version)}, "
+                f"which is not ahead of {format_version(UNRELEASED)} — the version that means "
+                "unreleased. Bump it when the first release is ready"
+            )
+        found.append(Refusal(ALREADY_RELEASED, behind))
     if not request.notes.strip():
         found.append(
             Refusal(NO_NOTES, "the range renders no notes, so there is nothing to publish")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "turbobasic-github-actions"
-version = "0.1.0"
+version = "0.0.0"
 description = "Reusable GitHub Actions workflows for turboBasic repositories"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/test_release_decisions.py
+++ b/tests/test_release_decisions.py
@@ -14,6 +14,7 @@ from decisions import (
     NOTICE,
     OFF_DEFAULT_BRANCH,
     ROUTINE,
+    UNRELEASED,
     Refusal,
     Request,
     Surface,
@@ -350,3 +351,31 @@ def test_a_bumped_version_that_breaks_its_own_released_line_is_an_error_on_any_o
         )
         assert verdict.proceed is False, occasion
         assert verdict.severity == ERROR, occasion
+
+
+def test_the_unreleased_version_is_not_ahead_of_itself() -> None:
+    # What makes 0.0.0 mean "not released yet": with no releases the baseline is itself, so it is
+    # refused, and a routine merge declines quietly for as long as the manifest stands there.
+    behind = ADMITTED._replace(version_text="0.0.0", existing=())
+    assert [r.key for r in refusals(behind)] == [ALREADY_RELEASED]
+    assert "unreleased" in refusals(behind)[0].message
+    verdict = decide(behind._replace(occasion=ROUTINE))
+    assert verdict.proceed is False
+    assert verdict.severity == NOTICE
+
+
+def test_asking_deliberately_to_release_the_unreleased_version_is_an_error() -> None:
+    verdict = decide(ADMITTED._replace(version_text="0.0.0", existing=(), occasion=DELIBERATE))
+    assert verdict.proceed is False
+    assert verdict.severity == ERROR
+
+
+def test_any_version_ahead_of_the_baseline_is_admitted_with_no_releases() -> None:
+    for text in ("0.0.1", "0.1.0", "1.0.0"):
+        assert refusals(ADMITTED._replace(version_text=text, existing=())) == [], text
+
+
+def test_the_baseline_is_the_lowest_version_there_is() -> None:
+    # Nothing can sit below it, so no version is unreachable by a bump.
+    assert UNRELEASED == (0, 0, 0)
+    assert parse_version("0.0.0") == UNRELEASED

--- a/uv.lock
+++ b/uv.lock
@@ -626,7 +626,7 @@ wheels = [
 
 [[package]]
 name = "turbobasic-github-actions"
-version = "0.1.0"
+version = "0.0.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What changed

- feat: measure an unreleased repository against 0.0.0

## Why?

With no releases, `not ahead of the highest release` could never fire, so any parseable version passed
every refusal and the next merge published it. The gate that holds every later merge was missing for
precisely the one release that cannot be withdrawn — and there was no way to keep a repository
unreleased through a long initial development.

## Blast radius

Nothing is released, so no consumer can observe the old behaviour. `0.0.0` stops being releasable, which
is the point; every other version behaves as before.

This repository's manifest goes to `0.0.0` in the same change, so merging #9 will arm the release path
without releasing anything.

## Verification

83 tests offline, four of them new. Exercised through the action's environment edge against `main`'s real
state: `0.0.0` declines with `proceed=false` and exit 0, `0.0.1` and `0.1.0` proceed.

## Docs

README's `release` section states the hold: stay at `0.0.0` for as long as it takes, then bump. Nothing
to switch off afterwards.

## Commits

- feat: measure an unreleased repository against 0.0.0

  The refusal ladder had no baseline until a first release existed, so with no
  releases any parseable version passed every refusal and the next merge to the
  default branch published it. The gate that holds every later merge was absent
  for exactly the one release that cannot be withdrawn.

  Absence of releases is now a baseline of 0.0.0 rather than no baseline at all.
  That is what makes 0.0.0 mean "not released yet": it is not ahead of itself, so
  it is refused, and after #10 a routine merge declines quietly. A repository can
  sit there for as long as it takes to have something worth publishing, then bump.

  Chosen over the alternatives because it adds nothing. No new refusal, no input,
  no configuration key, no state to remember and nothing to switch off afterwards
  — the version is the state, and it is visible in the manifest. A `-dev` suffix
  would have been refused as malformed and reddened the branch on every merge; a
  `hold` key would have been a switch someone has to remove.

  This repository's own manifest goes to 0.0.0 with it, so merging the change that
  arms the release path releases nothing.

  One consequence worth knowing: from 0.0.0 the proposal computes 0.0.1, because
  the line owns the minor and a feature advances only the patch. A first release of
  0.1.0 means overriding the proposal once, which is what a human's version on the
  proposal branch is for.

