### PR TITLE
feat: the ruleset in the tree

### DIFF
--- a/.github/rulesets/protect-default-branch.json
+++ b/.github/rulesets/protect-default-branch.json
@@ -1,0 +1,49 @@
+{
+  "name": "protect-default-branch",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "ci / python-ci"
+          },
+          {
+            "context": "commits / pr-title"
+          },
+          {
+            "context": "commits / commit-messages"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/workflows/apply-ruleset.yml
+++ b/.github/workflows/apply-ruleset.yml
@@ -1,0 +1,100 @@
+name: apply-ruleset
+
+# A ruleset is administrative surface with no revert once written, so this only ever runs by hand. It
+# defaults to a dry run: the difference between the committed file and the live ruleset always prints
+# before anything is written, so a person reads it before choosing to proceed.
+on:
+  workflow_dispatch:
+    inputs:
+      ruleset:
+        description: Name of the committed file under .github/rulesets, without the .json suffix.
+        required: true
+      dry-run:
+        description: Print the difference and stop before writing.
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  apply:
+    name: apply
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # the checkout, to read the committed file
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-administration: write # the only right a ruleset read or write needs (R8)
+
+      - name: Read the live rulesets
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh api "repos/$GH_REPO/rulesets" > "$RUNNER_TEMP/live.json"
+
+      - id: match
+        name: Find the one candidate this committed file names, if exactly one
+        env:
+          COMMITTED: .github/rulesets/${{ inputs.ruleset }}.json
+        run: |
+          name=$(jq -r .name "$COMMITTED")
+          ids=$(jq -r --arg name "$name" \
+            '[.[] | select(.source_type == "Repository" and .name == $name) | .id]' \
+            "$RUNNER_TEMP/live.json")
+          printf 'count=%s\n' "$(jq 'length' <<< "$ids")" >> "$GITHUB_OUTPUT"
+          printf 'id=%s\n' "$(jq -r '.[0] // ""' <<< "$ids")" >> "$GITHUB_OUTPUT"
+
+      - name: Read the one detail
+        if: steps.match.outputs.count == '1'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          ID: ${{ steps.match.outputs.id }}
+        run: gh api "repos/$GH_REPO/rulesets/$ID" > "$RUNNER_TEMP/detail.json"
+
+      - id: decide
+        continue-on-error: true
+        uses: $/actions/ruleset-decisions
+        with:
+          committed: .github/rulesets/${{ inputs.ruleset }}.json
+          live: ${{ runner.temp }}/live.json
+          detail: ${{ steps.match.outputs.count == '1' && format('{0}/detail.json', runner.temp) || '' }}
+
+      - name: Print the difference
+        env:
+          DIFFERENCE: ${{ steps.decide.outputs.difference }}
+        run: printf '%s\n' "$DIFFERENCE"
+
+      - name: Refuse
+        if: steps.decide.outcome == 'failure'
+        run: exit 1
+
+      - name: Write the ruleset
+        if: >-
+          steps.decide.outcome == 'success' && inputs.dry-run == false &&
+          (steps.decide.outputs.verdict == 'create' || steps.decide.outputs.verdict == 'update')
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          VERDICT: ${{ steps.decide.outputs.verdict }}
+          RULESET_ID: ${{ steps.decide.outputs.ruleset-id }}
+          BODY: ${{ steps.decide.outputs.body }}
+        run: |
+          if [ "$VERDICT" = create ]; then
+            gh api "repos/$GH_REPO/rulesets" --input "$BODY"
+          else
+            gh api -X PUT "repos/$GH_REPO/rulesets/$RULESET_ID" --input "$BODY"
+          fi

--- a/.github/workflows/apply-ruleset.yml
+++ b/.github/workflows/apply-ruleset.yml
@@ -129,7 +129,8 @@ jobs:
 
       # The drift alarm. A dispatch exits successfully on a difference — that is the reason to dispatch
       # — but a scheduled run finding one means GitHub stopped matching the tree with nobody watching.
-      - name: Fail on drift
+      - id: drift
+        name: Fail on drift
         if: github.event_name == 'schedule' && steps.decide.outputs.verdict != 'nothing'
         env:
           MESSAGE: ${{ steps.decide.outputs.message }}

--- a/.github/workflows/apply-ruleset.yml
+++ b/.github/workflows/apply-ruleset.yml
@@ -44,17 +44,24 @@ jobs:
         with:
           persist-credentials: false
 
+      # An empty matrix skips the job below, and a skipped job reports success — so a scheduled run that
+      # listed nothing would be a green check that read no ruleset at all. It fails here instead.
       - id: list
         env:
           NAMED: ${{ inputs.ruleset }}
         run: |
           if [ -n "$NAMED" ]; then
-            jq -cn --arg one "$NAMED" '{rulesets: [$one]}'
+            names=$(jq -cn --arg one "$NAMED" '[$one]')
           else
-            find .github/rulesets -name '*.json' -printf '%f\n' \
+            names=$(find .github/rulesets -name '*.json' -printf '%f\n' \
               | sed 's/\.json$//' \
-              | jq -Rcn '{rulesets: [inputs]}'
-          fi | jq -r 'to_entries[] | "\(.key)=\(.value | tojson)"' >> "$GITHUB_OUTPUT"
+              | jq -Rcn '[inputs]')
+          fi
+          if [ "$(jq 'length' <<< "$names")" -eq 0 ]; then
+            echo "::error::no committed ruleset to read under .github/rulesets"
+            exit 1
+          fi
+          printf 'rulesets=%s\n' "$names" >> "$GITHUB_OUTPUT"
 
   apply:
     name: apply

--- a/.github/workflows/apply-ruleset.yml
+++ b/.github/workflows/apply-ruleset.yml
@@ -1,8 +1,13 @@
 name: apply-ruleset
 
-# A ruleset is administrative surface with no revert once written, so this only ever runs by hand. It
+# A ruleset is administrative surface with no revert once written, so a write only ever runs by hand. It
 # defaults to a dry run: the difference between the committed file and the live ruleset always prints
 # before anything is written, so a person reads it before choosing to proceed.
+#
+# The schedule writes nothing and cannot: the write step is reachable from `workflow_dispatch` alone
+# (FR-003). It exists because the tree is only authoritative if something notices when GitHub stops
+# matching it — a hand edit in the UI is otherwise invisible until the next dispatch, which may be
+# months away. So the scheduled run reads, and fails on any difference.
 on:
   workflow_dispatch:
     inputs:
@@ -13,6 +18,8 @@ on:
         description: Print the difference and stop before writing.
         type: boolean
         default: true
+  schedule:
+    - cron: "17 6 * * 1" # Monday morning, so a week's drift is read at the start of a week
 
 concurrency:
   group: ${{ github.workflow }}
@@ -21,12 +28,45 @@ concurrency:
 permissions: {}
 
 jobs:
+  # Which committed rulesets this run is about: the one the dispatch named, or every file in the tree
+  # when nothing named one. Hardcoding a name for the scheduled path would fork the fact that
+  # `.github/rulesets/` owns — which rulesets exist — so the directory is read instead.
+  which:
+    name: which
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read # the checkout, to list the committed files
+    outputs:
+      rulesets: ${{ steps.list.outputs.rulesets }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - id: list
+        env:
+          NAMED: ${{ inputs.ruleset }}
+        run: |
+          if [ -n "$NAMED" ]; then
+            jq -cn --arg one "$NAMED" '{rulesets: [$one]}'
+          else
+            find .github/rulesets -name '*.json' -printf '%f\n' \
+              | sed 's/\.json$//' \
+              | jq -Rcn '{rulesets: [inputs]}'
+          fi | jq -r 'to_entries[] | "\(.key)=\(.value | tojson)"' >> "$GITHUB_OUTPUT"
+
   apply:
     name: apply
+    needs: which
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read # the checkout, to read the committed file
+    strategy:
+      fail-fast: false # one ruleset's refusal must not hide another's difference
+      matrix:
+        ruleset: ${{ fromJSON(needs.which.outputs.rulesets) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -39,39 +79,24 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-administration: write # the only right a ruleset read or write needs (R8)
 
-      - name: Read the live rulesets
+      # Every repository-owned ruleset in full, because the list endpoint's summary carries no rules,
+      # conditions or bypass_actors. `includes_parents=false` is what leaves out an organisation's,
+      # which this repository could not write even if it matched a committed name.
+      - name: Read the live rulesets in full
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh api "repos/$GH_REPO/rulesets" > "$RUNNER_TEMP/live.json"
-
-      - id: match
-        name: Find the one candidate this committed file names, if exactly one
-        env:
-          COMMITTED: .github/rulesets/${{ inputs.ruleset }}.json
         run: |
-          name=$(jq -r .name "$COMMITTED")
-          ids=$(jq -r --arg name "$name" \
-            '[.[] | select(.source_type == "Repository" and .name == $name) | .id]' \
-            "$RUNNER_TEMP/live.json")
-          printf 'count=%s\n' "$(jq 'length' <<< "$ids")" >> "$GITHUB_OUTPUT"
-          printf 'id=%s\n' "$(jq -r '.[0] // ""' <<< "$ids")" >> "$GITHUB_OUTPUT"
-
-      - name: Read the one detail
-        if: steps.match.outputs.count == '1'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-          ID: ${{ steps.match.outputs.id }}
-        run: gh api "repos/$GH_REPO/rulesets/$ID" > "$RUNNER_TEMP/detail.json"
+          gh api "repos/$GH_REPO/rulesets?includes_parents=false" --jq '.[].id' \
+            | while read -r id; do gh api "repos/$GH_REPO/rulesets/$id"; done \
+            | jq -sc '.' > "$RUNNER_TEMP/live.json"
 
       - id: decide
         continue-on-error: true
         uses: $/actions/ruleset-decisions
         with:
-          committed: .github/rulesets/${{ inputs.ruleset }}.json
+          committed: .github/rulesets/${{ matrix.ruleset }}.json
           live: ${{ runner.temp }}/live.json
-          detail: ${{ steps.match.outputs.count == '1' && format('{0}/detail.json', runner.temp) || '' }}
 
       - name: Print the difference
         env:
@@ -82,9 +107,12 @@ jobs:
         if: steps.decide.outcome == 'failure'
         run: exit 1
 
+      # `inputs.dry-run` is absent on a scheduled run, and an absent input compares equal to `false` —
+      # so the event is named first. A schedule reads and never writes (FR-003).
       - name: Write the ruleset
         if: >-
-          steps.decide.outcome == 'success' && inputs.dry-run == false &&
+          github.event_name == 'workflow_dispatch' && steps.decide.outcome == 'success' &&
+          !inputs.dry-run &&
           (steps.decide.outputs.verdict == 'create' || steps.decide.outputs.verdict == 'update')
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -98,3 +126,13 @@ jobs:
           else
             gh api -X PUT "repos/$GH_REPO/rulesets/$RULESET_ID" --input "$BODY"
           fi
+
+      # The drift alarm. A dispatch exits successfully on a difference — that is the reason to dispatch
+      # — but a scheduled run finding one means GitHub stopped matching the tree with nobody watching.
+      - name: Fail on drift
+        if: github.event_name == 'schedule' && steps.decide.outputs.verdict != 'nothing'
+        env:
+          MESSAGE: ${{ steps.decide.outputs.message }}
+        run: |
+          printf '::error::live ruleset no longer matches the tree: %s\n' "$MESSAGE"
+          exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: end-of-file-fixer
         exclude: *vendored_speckit
       - id: check-toml
+      - id: check-json
       - id: check-added-large-files
       - id: check-merge-conflict
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,5 +38,6 @@ and reaches the rule layers by link. Layer 3 is read on demand by both.
 | `pyproject.toml` | the Python dependencies, the tool settings, and the released version |
 | `.pre-commit-config.yaml` | the prek hooks |
 | `.github/workflows/ci.yml` | which gates run on a pull request |
+| `.github/rulesets/` | what the default branch requires, and what a consumer's ruleset would require of it |
 | `.github/ISSUE_TEMPLATE/`, `.github/PULL_REQUEST_TEMPLATE.md` | what a report or a proposal has to carry |
 | `.yamllint.yaml`, `.cspell.config.yaml`, `.markdownlint-cli2.jsonc`, `.taplo.toml` | each linter's own rules and exemptions |

--- a/actions/ruleset-decisions/action.yml
+++ b/actions/ruleset-decisions/action.yml
@@ -1,0 +1,55 @@
+name: ruleset-decisions
+description: >-
+  Answers what to do with a committed ruleset given the live rulesets on the repository — create,
+  update, do nothing, or refuse. Internal surface: it carries no stability promise and composes no check
+  name. Performs no write and reads no network; every HTTP call is the workflow's.
+
+inputs:
+  committed:
+    description: Path to the committed ruleset JSON.
+    required: true
+  live:
+    description: Path to the JSON body of `GET /repos/{owner}/{repo}/rulesets`.
+    required: true
+  detail:
+    description: >-
+      Path to the JSON body of `GET /repos/{owner}/{repo}/rulesets/{id}` for the one ruleset whose
+      name and source_type matched in `live`. Absent unless exactly one match exists.
+    required: false
+    default: ""
+  body-path:
+    description: Where to write the body to send, for create or update. Absent otherwise.
+    required: false
+    default: ""
+
+outputs:
+  verdict:
+    description: nothing, create, update or refuse.
+    value: ${{ steps.decide.outputs.verdict }}
+  ruleset-id:
+    description: The live ruleset's id, for update. Empty otherwise.
+    value: ${{ steps.decide.outputs.ruleset-id }}
+  difference:
+    description: Field by field, both sides. Empty only for nothing.
+    value: ${{ steps.decide.outputs.difference }}
+  body:
+    description: Path to the JSON to send. Written for create and update.
+    value: ${{ steps.decide.outputs.body }}
+  message:
+    description: What was read, what it was compared against, and what to do about it.
+    value: ${{ steps.decide.outputs.message }}
+
+runs:
+  using: composite
+  steps:
+    # Every value reaches the module as an environment value, never interpolated into a command line —
+    # a committed file's path is chosen by this repository, but the live and detail bodies it is
+    # compared against are text this workflow read from an API response.
+    - id: decide
+      shell: bash
+      env:
+        COMMITTED: ${{ inputs.committed }}
+        LIVE: ${{ inputs.live }}
+        DETAIL: ${{ inputs.detail }}
+        BODY_PATH: ${{ inputs.body-path || format('{0}/ruleset-body.json', runner.temp) }}
+      run: python3 "$GITHUB_ACTION_PATH/rulesets.py"

--- a/actions/ruleset-decisions/action.yml
+++ b/actions/ruleset-decisions/action.yml
@@ -9,14 +9,11 @@ inputs:
     description: Path to the committed ruleset JSON.
     required: true
   live:
-    description: Path to the JSON body of `GET /repos/{owner}/{repo}/rulesets`.
-    required: true
-  detail:
     description: >-
-      Path to the JSON body of `GET /repos/{owner}/{repo}/rulesets/{id}` for the one ruleset whose
-      name and source_type matched in `live`. Absent unless exactly one match exists.
-    required: false
-    default: ""
+      Path to a JSON array of every repository-owned ruleset as `GET
+      /repos/{owner}/{repo}/rulesets/{id}` returns it. The list endpoint's summaries will not do: they
+      carry no rules, conditions or bypass_actors, so nothing could be compared.
+    required: true
   body-path:
     description: Where to write the body to send, for create or update. Absent otherwise.
     required: false
@@ -50,6 +47,5 @@ runs:
       env:
         COMMITTED: ${{ inputs.committed }}
         LIVE: ${{ inputs.live }}
-        DETAIL: ${{ inputs.detail }}
         BODY_PATH: ${{ inputs.body-path || format('{0}/ruleset-body.json', runner.temp) }}
       run: python3 "$GITHUB_ACTION_PATH/rulesets.py"

--- a/actions/ruleset-decisions/rulesets.py
+++ b/actions/ruleset-decisions/rulesets.py
@@ -107,7 +107,10 @@ def render_difference(committed: Doc, live: Doc) -> str:
     return "\n".join(lines)
 
 
-def decide(committed: Doc, live_list: list[Doc], detail: Doc | None) -> Verdict:
+def decide(committed: Doc, live: list[Doc]) -> Verdict:
+    # `live` is every repository-owned ruleset as the detail endpoint returns it, not the list
+    # endpoint's summaries: the summary carries no rules, conditions or bypass_actors, so a caller
+    # handing those over would be comparing the committed file against fields that are simply absent.
     problem = shape_problem(committed)
     if problem:
         return Verdict(REFUSE, "", "", None, problem)
@@ -115,7 +118,7 @@ def decide(committed: Doc, live_list: list[Doc], detail: Doc | None) -> Verdict:
     name = str(committed["name"])
     matches = [
         ruleset
-        for ruleset in live_list
+        for ruleset in live
         if ruleset.get("source_type") == "Repository" and ruleset.get("name") == name
     ]
 
@@ -141,19 +144,8 @@ def decide(committed: Doc, live_list: list[Doc], detail: Doc | None) -> Verdict:
         )
 
     live_id = str(matches[0].get("id", ""))
-    if detail is None:
-        return Verdict(
-            REFUSE,
-            "",
-            "",
-            None,
-            f"exactly one ruleset named {name!r} exists (id {live_id}), but its full detail was not "
-            "read — the list endpoint carries no rules, conditions or bypass_actors to compare "
-            "against. Fetch GET /repos/{owner}/{repo}/rulesets/{id} before deciding",
-        )
-
     committed_norm = normalize(committed)
-    live_norm = normalize(detail)
+    live_norm = normalize(matches[0])
     if committed_norm == live_norm:
         return Verdict(
             NOTHING,
@@ -203,12 +195,12 @@ def annotate(severity: str, message: str) -> None:
 
 
 def main() -> int:
-    committed = read_doc(read_text("COMMITTED"))
-    live_list = read_list(read_text("LIVE"))
-    detail_path = read_text("DETAIL")
-    detail = read_doc(detail_path) if detail_path else None
+    committed_path = read_text("COMMITTED")
+    if not os.path.isfile(committed_path):
+        annotate("error", f"no committed ruleset at {committed_path!r} — check the dispatch's name")
+        return 1
 
-    verdict = decide(committed, live_list, detail)
+    verdict = decide(read_doc(committed_path), read_list(read_text("LIVE")))
 
     body_path = read_text("BODY_PATH")
     if verdict.body is not None and body_path:

--- a/actions/ruleset-decisions/rulesets.py
+++ b/actions/ruleset-decisions/rulesets.py
@@ -1,0 +1,232 @@
+import json
+import os
+import sys
+from typing import Any, NamedTuple, cast
+
+Doc = dict[str, Any]
+
+# The six fields a write to the rulesets API accepts. tests/capabilities.py owns the same fact for the
+# gate that reads the committed file from the tree; this module owns it for the workflow that writes it,
+# and neither imports the other — the action ships alone, and the suite runs with no network.
+WRITABLE_FIELDS = frozenset(
+    {"name", "target", "enforcement", "conditions", "rules", "bypass_actors"}
+)
+
+NOTHING = "nothing"
+CREATE = "create"
+UPDATE = "update"
+REFUSE = "refuse"
+
+
+class Verdict(NamedTuple):
+    verdict: str
+    ruleset_id: str
+    difference: str
+    body: Doc | None
+    message: str
+
+
+def shape_problem(committed: Doc) -> str | None:
+    unknown = sorted(set(committed) - WRITABLE_FIELDS)
+    if unknown:
+        return (
+            f"the committed ruleset names {unknown}, and a write accepts only "
+            f"{sorted(WRITABLE_FIELDS)}. A misspelled field reads as an absent one — fix the key"
+        )
+    missing = sorted(WRITABLE_FIELDS - set(committed))
+    if missing:
+        return f"the committed ruleset omits {missing}, which a write requires"
+    if committed.get("target") != "branch":
+        return f"the committed ruleset's target is {committed.get('target')!r}; only 'branch' is in scope"
+    rules = cast(list[Doc], committed["rules"])
+    rule_types = [str(rule.get("type")) for rule in rules]
+    checks_rules = [rule for rule in rules if rule.get("type") == "required_status_checks"]
+    if len(checks_rules) != 1:
+        return (
+            f"the committed ruleset's rule types are {rule_types}, and exactly one must be "
+            "'required_status_checks' — a ruleset requiring nothing gates nothing"
+        )
+    contexts = cast(
+        list[Doc], checks_rules[0].get("parameters", {}).get("required_status_checks", [])
+    )
+    if not contexts or any(not check.get("context") for check in contexts):
+        return (
+            "the committed ruleset's required-status-checks list is empty or carries an empty "
+            "context; the context gate would pass on an empty set"
+        )
+    return None
+
+
+def normalize(doc: Doc) -> Doc:
+    # R4: a read orders lists as it pleases and fills defaults the file may omit. Sorting both sides
+    # the same way, and comparing only the six writable fields, is what keeps a dispatch from reporting
+    # drift it did not cause.
+    projected: Doc = {field: doc.get(field) for field in WRITABLE_FIELDS}
+
+    rules = sorted(
+        cast(list[Doc], projected.get("rules") or []), key=lambda rule: str(rule.get("type"))
+    )
+    normalized_rules: list[Doc] = []
+    for rule in rules:
+        rule = dict(rule)
+        if rule.get("type") == "required_status_checks":
+            params = dict(cast(Doc, rule.get("parameters") or {}))
+            params["required_status_checks"] = sorted(
+                cast(list[Doc], params.get("required_status_checks") or []),
+                key=lambda check: str(check.get("context")),
+            )
+            rule["parameters"] = params
+        normalized_rules.append(rule)
+    projected["rules"] = normalized_rules
+
+    projected["bypass_actors"] = sorted(
+        cast(list[Doc], projected.get("bypass_actors") or []),
+        key=lambda actor: (str(actor.get("actor_type")), actor.get("actor_id")),
+    )
+
+    conditions = dict(cast(Doc, projected.get("conditions") or {}))
+    ref_name = dict(cast(Doc, conditions.get("ref_name") or {}))
+    ref_name["include"] = sorted(
+        str(name) for name in cast(list[Any], ref_name.get("include") or [])
+    )
+    ref_name["exclude"] = sorted(
+        str(name) for name in cast(list[Any], ref_name.get("exclude") or [])
+    )
+    conditions["ref_name"] = ref_name
+    projected["conditions"] = conditions
+
+    return projected
+
+
+def render_difference(committed: Doc, live: Doc) -> str:
+    lines = [
+        f"{field}: committed={committed.get(field)!r} live={live.get(field)!r}"
+        for field in sorted(WRITABLE_FIELDS)
+        if committed.get(field) != live.get(field)
+    ]
+    return "\n".join(lines)
+
+
+def decide(committed: Doc, live_list: list[Doc], detail: Doc | None) -> Verdict:
+    problem = shape_problem(committed)
+    if problem:
+        return Verdict(REFUSE, "", "", None, problem)
+
+    name = str(committed["name"])
+    matches = [
+        ruleset
+        for ruleset in live_list
+        if ruleset.get("source_type") == "Repository" and ruleset.get("name") == name
+    ]
+
+    if len(matches) > 1:
+        ids = [str(ruleset.get("id")) for ruleset in matches]
+        return Verdict(
+            REFUSE,
+            "",
+            "",
+            None,
+            f"{len(matches)} rulesets named {name!r} exist on this repository, ids {ids} — the API "
+            "does not make names unique. Resolve which one is meant before applying",
+        )
+
+    if not matches:
+        body = {field: committed[field] for field in WRITABLE_FIELDS}
+        return Verdict(
+            CREATE,
+            "",
+            "",
+            body,
+            f"no ruleset named {name!r} exists on this repository; the committed file becomes a new one",
+        )
+
+    live_id = str(matches[0].get("id", ""))
+    if detail is None:
+        return Verdict(
+            REFUSE,
+            "",
+            "",
+            None,
+            f"exactly one ruleset named {name!r} exists (id {live_id}), but its full detail was not "
+            "read — the list endpoint carries no rules, conditions or bypass_actors to compare "
+            "against. Fetch GET /repos/{owner}/{repo}/rulesets/{id} before deciding",
+        )
+
+    committed_norm = normalize(committed)
+    live_norm = normalize(detail)
+    if committed_norm == live_norm:
+        return Verdict(
+            NOTHING,
+            live_id,
+            "",
+            None,
+            f"{name!r} already matches the committed file; nothing to change",
+        )
+
+    body = {field: committed[field] for field in WRITABLE_FIELDS}
+    difference = render_difference(committed_norm, live_norm)
+    return Verdict(
+        UPDATE,
+        live_id,
+        difference,
+        body,
+        f"{name!r} (id {live_id}) differs from the committed file; see the printed difference",
+    )
+
+
+def read_text(name: str) -> str:
+    return os.environ.get(name, "")
+
+
+def read_doc(path: str) -> Doc:
+    with open(path, encoding="utf-8") as handle:
+        return cast(Doc, json.load(handle))
+
+
+def read_list(path: str) -> list[Doc]:
+    with open(path, encoding="utf-8") as handle:
+        return cast(list[Doc], json.load(handle))
+
+
+def emit(values: dict[str, str]) -> None:
+    path = read_text("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for name, value in values.items():
+            # A value may hold newlines — the difference does — so every output uses the delimiter form.
+            handle.write(f"{name}<<__RULESET_DECISIONS__\n{value}\n__RULESET_DECISIONS__\n")
+
+
+def annotate(severity: str, message: str) -> None:
+    print(f"::{severity}::{message}", file=sys.stderr if severity == "error" else sys.stdout)
+
+
+def main() -> int:
+    committed = read_doc(read_text("COMMITTED"))
+    live_list = read_list(read_text("LIVE"))
+    detail_path = read_text("DETAIL")
+    detail = read_doc(detail_path) if detail_path else None
+
+    verdict = decide(committed, live_list, detail)
+
+    body_path = read_text("BODY_PATH")
+    if verdict.body is not None and body_path:
+        with open(body_path, "w", encoding="utf-8") as handle:
+            json.dump(verdict.body, handle, indent=2)
+
+    emit(
+        {
+            "verdict": verdict.verdict,
+            "ruleset-id": verdict.ruleset_id,
+            "difference": verdict.difference,
+            "body": body_path if verdict.body is not None else "",
+            "message": verdict.message,
+        }
+    )
+    annotate("error" if verdict.verdict == REFUSE else "notice", verdict.message)
+    return 1 if verdict.verdict == REFUSE else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -164,12 +164,10 @@ Python 3.14. The only Python here supports the actions and their tests.
 
 `mise run ci` reproduces CI locally.
 
-**This repository's own branch ruleset is a consumer of its own check names, and nothing in the tree can
-see it.** Renaming a job, removing one, or making a job conditional changes what reports — so the same
-change edits the ruleset's required contexts. The rule is principle IV's, and the README already states
-it for consumers; it binds here too, and forgetting it is not a small mistake. A required context that
-no longer reports blocks every pull request in this repository, and the only symptom is a check that
-never appears.
-
-Two names are never required: `advisory / prek-advisory`, which is advertised as advisory and reports
-green whether or not it found anything, and any context from a capability whose job can skip.
+**This repository's own branch ruleset is a consumer of its own check names, and `.github/rulesets/`
+is where it is committed.** `tests/test_ruleset_contexts.py` is what holds it: renaming a job, retiring
+a workflow, or making a job conditional changes what a required context there composes to, and the gate
+fails the pull request that does it, naming the ruleset, the context, and what to edit. The rule is
+principle IV's, and the README already states it for consumers; it binds here too, and forgetting it is
+not a small mistake. A required context that no longer reports blocks every pull request in this
+repository, and the only symptom is a check that never appears.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,11 @@ ignore = ["E501"] # line length is the formatter's job
 
 [tool.pyright]
 include = ["actions", "tests"]
-# Two modules the tests import by bare name: `tests/capabilities.py`, the one owner of how a workflow
-# is read, and the decision unit, which lives beside the action that runs it. pytest reaches the first
-# by the test file's own directory and the second through `tests/conftest.py`; pyright needs both
-# directories named here to resolve either import.
-extraPaths = ["tests", "actions/release-decisions"]
+# Modules the tests import by bare name: `tests/capabilities.py`, the one owner of how a workflow is
+# read, and each decision unit, which lives beside the action that runs it. pytest reaches the first by
+# the test file's own directory and the rest through `tests/conftest.py`; pyright needs every directory
+# named here to resolve any of them.
+extraPaths = ["tests", "actions/release-decisions", "actions/ruleset-decisions"]
 pythonVersion = "3.14"
 typeCheckingMode = "strict"
 venvPath = "."
@@ -69,6 +69,7 @@ exclude = [
   ".github/workflows/describe-pr.yml",
   ".github/workflows/release-on-merge.yml",
   ".github/workflows/release-proposal.yml",
+  "actions/ruleset-decisions",
 ]
 
 [tool.commitizen]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ addopts = ["-ra"]
 include = [".github/workflows", "actions"]
 exclude = [
   ".github/workflows/advisory.yml",
+  ".github/workflows/apply-ruleset.yml",
   ".github/workflows/ci.yml",
   ".github/workflows/commit-messages.yml",
   ".github/workflows/describe-pr.yml",

--- a/specs/002-ruleset-in-tree/checklists/requirements.md
+++ b/specs/002-ruleset-in-tree/checklists/requirements.md
@@ -1,0 +1,51 @@
+# Specification Quality Checklist: The Ruleset In The Tree
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+The stakeholder here is a maintainer of a CI repository, so "non-technical" is read as *not presuming
+the implementation*: the spec names rulesets, required contexts and events, which are the domain, and
+names no language, no library and no API endpoint. FR-012 deliberately says the file is schema-validated
+without naming the validator's flag; the Assumptions section carries what the plan has to settle.
+
+FR-013 and SC-006 exist because this feature must be a no-op on what is enforced. A spec that changed
+the ruleset's contents at the same time as moving its ownership would leave nobody able to say which
+half caused a subsequent block.
+
+Two decisions arrived settled and are recorded in the Decisions section rather than as clarification
+questions: dispatch-only applying, and never overwriting a hand edit. `/speckit-clarify` has nothing left
+to ask on either.
+
+Amended during `/speckit-plan`, while still Draft: FR-005 as first written contradicted FR-002, because a
+difference between live and committed is the only reason to apply, and the ruleset history API returns
+`actor` as `null` so the difference cannot be attributed. FR-004 to FR-006 now describe one dry-run input
+rather than two, and FR-012 says what must be asserted rather than which tool asserts it. Both are recorded
+in [research.md](../research.md) as R9 and R2.

--- a/specs/002-ruleset-in-tree/contracts/ruleset-decisions.md
+++ b/specs/002-ruleset-in-tree/contracts/ruleset-decisions.md
@@ -1,0 +1,84 @@
+# Contract: `actions/ruleset-decisions`
+
+Internal surface. No stability promise, no check name, no consumer. `published = false` in
+`tests/published_surface.toml`, and excluded from the release surface by R7 — nothing outside this
+repository can name it, so nothing it does moves a version.
+
+It answers one question and performs no write. Every HTTP call is the workflow's.
+
+## Inputs
+
+Read from the environment, declared in `action.yml`, never interpolated into a command line (principle
+VI).
+
+| Input | Environment | Required | Meaning |
+| --- | --- | --- | --- |
+| `committed` | `COMMITTED` | yes | Path to the committed ruleset JSON |
+| `live` | `LIVE` | yes | Path to the JSON body of `GET /repos/{owner}/{repo}/rulesets`, as the workflow saved it |
+| `body-path` | `BODY_PATH` | no | Where to write the body to send. Defaults under `RUNNER_TEMP` |
+
+`live` is a path rather than a value: it is an API response of unbounded size, and a response is text
+chosen outside this repository.
+
+## Outputs
+
+| Output | Meaning |
+| --- | --- |
+| `verdict` | `nothing`, `create`, `update` or `refuse` |
+| `ruleset-id` | The live ruleset's id, for `update`. Empty otherwise |
+| `difference` | Field by field, both sides. Empty only for `nothing` |
+| `body` | Path to the JSON to send. Written for `create` and `update` |
+| `message` | What was read, what it was compared against, and what to do about it |
+
+## Behaviour
+
+1. Load `committed`. Validate its shape against the rules in [data-model.md](../data-model.md#validation).
+   A failure is a `refuse` naming the offending key, not an exception.
+2. From `live`, keep only entries whose `source_type` is `Repository` and whose `name` equals the
+   committed `name`. More than one is a `refuse` (FR-007). None is a `create`.
+3. Project the one match onto the committed file's six fields, normalise both by R4's sort order, and
+   compare.
+4. Equal → `nothing`. Different → `update`, with `difference` rendered field by field and `body` written.
+
+Nothing in this module reads the network, reads `GITHUB_TOKEN`, or writes outside `body-path`. That is
+what makes it testable offline, which FR-011 requires of the suite that tests it.
+
+## Failure messages
+
+Every one names what was read, what it was compared against, and what a maintainer should do — the
+conventions layer's rule for a capability, applied here because the failures are the product.
+
+| Situation | Names |
+| --- | --- |
+| unknown key in the committed file | the key, the six accepted, and that a write rejects anything else |
+| no `required_status_checks` rule | the rule types found, and that a ruleset requiring nothing gates nothing |
+| empty context list | the file, and that the context gate would pass on an empty set |
+| two rulesets share the name | both ids, both `source_type`s, and that the API does not make names unique |
+
+## What the workflow does around it
+
+`.github/workflows/apply-ruleset.yml`, dispatch only (FR-003), one job, `timeout-minutes` set, every
+permission carrying its reason on the same line — `test_every_permission_carries_its_reason_beside_it`
+reads the action tree and the workflow tree alike.
+
+```text
+inputs:
+  ruleset   which committed file to apply
+  dry-run   default true — the only input governing whether anything is written (FR-004, R9)
+
+steps:
+  checkout                              contents: read
+  mint App token                        permission-administration: write   (R8)
+  gh api  .../rulesets            ->    $RUNNER_TEMP/live.json
+  uses: $/actions/ruleset-decisions
+  print the difference                  always, whether or not it writes  (FR-005)
+  refuse                                if verdict == refuse
+  gh api --input "$body"                if verdict in (create, update) and dry-run is off
+```
+
+The body goes in through `--input`, never as an argument (principle VI). The token reaches `gh` as
+`GH_TOKEN` in the step's `env`, and is written nowhere (principle II).
+
+The workflow composes the context `apply-ruleset / apply`. It fires on no pull request, so it can never
+report on one and must never appear in a committed required list — which
+[FR-009](../spec.md#functional-requirements) enforces rather than merely asks.

--- a/specs/002-ruleset-in-tree/contracts/ruleset-decisions.md
+++ b/specs/002-ruleset-in-tree/contracts/ruleset-decisions.md
@@ -15,7 +15,14 @@ VI).
 | --- | --- | --- | --- |
 | `committed` | `COMMITTED` | yes | Path to the committed ruleset JSON |
 | `live` | `LIVE` | yes | Path to the JSON body of `GET /repos/{owner}/{repo}/rulesets`, as the workflow saved it |
+| `detail` | `DETAIL` | no | Path to the JSON body of `GET /repos/{owner}/{repo}/rulesets/{id}` for the one ruleset whose name and `source_type` matched in `live`. Absent unless exactly one match exists |
 | `body-path` | `BODY_PATH` | no | Where to write the body to send. Defaults under `RUNNER_TEMP` |
+
+`live` alone cannot decide `update` versus `nothing`: `GET /repos/{owner}/{repo}/rulesets` (the list) carries
+`id`, `name`, `target`, `source_type`, `enforcement` and the read-only timestamps, but not `rules`,
+`conditions` or `bypass_actors` — verified live against this repository's own ruleset, not assumed. Only
+once exactly one match is found by name is there a single id to fetch detail for, so the workflow reads
+`live` first, and reads `detail` only when that leaves exactly one candidate.
 
 `live` is a path rather than a value: it is an API response of unbounded size, and a response is text
 chosen outside this repository.
@@ -36,9 +43,12 @@ chosen outside this repository.
    A failure is a `refuse` naming the offending key, not an exception.
 2. From `live`, keep only entries whose `source_type` is `Repository` and whose `name` equals the
    committed `name`. More than one is a `refuse` (FR-007). None is a `create`.
-3. Project the one match onto the committed file's six fields, normalise both by R4's sort order, and
-   compare.
-4. Equal → `nothing`. Different → `update`, with `difference` rendered field by field and `body` written.
+3. Exactly one, and `detail` is absent: `refuse`, naming the id and that its detail must be read first.
+   The workflow is expected never to hit this — it fetches `detail` whenever `live` leaves one candidate —
+   so reaching it means the workflow and this contract have drifted.
+4. Exactly one, and `detail` is present: project it and `committed` onto the committed file's six fields,
+   normalise both by R4's sort order, and compare.
+5. Equal → `nothing`. Different → `update`, with `difference` rendered field by field and `body` written.
 
 Nothing in this module reads the network, reads `GITHUB_TOKEN`, or writes outside `body-path`. That is
 what makes it testable offline, which FR-011 requires of the suite that tests it.
@@ -70,6 +80,8 @@ steps:
   checkout                              contents: read
   mint App token                        permission-administration: write   (R8)
   gh api  .../rulesets            ->    $RUNNER_TEMP/live.json
+  find the one id matching name + source_type == Repository, if exactly one
+  gh api  .../rulesets/{id}       ->    $RUNNER_TEMP/detail.json   (only if exactly one)
   uses: $/actions/ruleset-decisions
   print the difference                  always, whether or not it writes  (FR-005)
   refuse                                if verdict == refuse
@@ -79,6 +91,7 @@ steps:
 The body goes in through `--input`, never as an argument (principle VI). The token reaches `gh` as
 `GH_TOKEN` in the step's `env`, and is written nowhere (principle II).
 
-The workflow composes the context `apply-ruleset / apply`. It fires on no pull request, so it can never
+The workflow composes the context `apply` — its job calls no reusable workflow, so nothing prefixes its
+own name. It fires on no pull request, so it can never
 report on one and must never appear in a committed required list — which
 [FR-009](../spec.md#functional-requirements) enforces rather than merely asks.

--- a/specs/002-ruleset-in-tree/data-model.md
+++ b/specs/002-ruleset-in-tree/data-model.md
@@ -54,9 +54,18 @@ the workflows plus `published_surface.toml` (R6).
 
 | Condition | Reason carried |
 | --- | --- |
-| the called capability records a `skips_under` entry covering the called job | that entry's own `reason`, quoted |
+| the called capability is marked `judges = false` in `published_surface.toml` | a fixed sentence naming the capability |
 | the calling job carries an `if:` | the condition, verbatim |
 | the calling workflow declares no `pull_request` trigger | the events it does declare |
+
+`judges = false` is a fact about the capability, not about the calling workflow: it means the job goes
+green without a pass/fail verdict on what it names, whether by design (advisory, so it reports success
+regardless of findings) or by nature (it writes rather than checks). `skips_under` records a different,
+narrower fact — that a job's own `if:` can skip it under some event — and does not by itself disqualify a
+context: `conventional-commits` records exactly such an entry for `pr-title` and `commit-messages`, and
+both are safe to require, because the one workflow that calls it never fires under the event the entry
+names. Conflating the two would fail `commits / pr-title` and `commits / commit-messages`, which FR-013
+forbids.
 
 A context with `cannot_judge` set may exist and may be advertised. It may not be required (FR-009).
 

--- a/specs/002-ruleset-in-tree/data-model.md
+++ b/specs/002-ruleset-in-tree/data-model.md
@@ -1,0 +1,92 @@
+# Data Model: The Ruleset In The Tree
+
+Three structures, one of them new to the tree. Each field below is owned by exactly one of them; a field
+appearing twice is named as derived from the other.
+
+## Committed ruleset
+
+`.github/rulesets/<name>.json`. The owner of what the default branch requires.
+
+Holds exactly the fields a write accepts (R1). Any other key is a validation failure, not an ignored one —
+a misspelled field would otherwise read as an absent one, and an absent one asserts nothing.
+
+| Field | Shape | Rule |
+| --- | --- | --- |
+| `name` | string | Non-empty. Matched against live rulesets to find the one to write (R5). |
+| `target` | string | `branch`. Nothing else is in scope. |
+| `enforcement` | string | `active`, `evaluate` or `disabled`. |
+| `conditions` | object | `ref_name.include` and `ref_name.exclude`, both lists. Today `["~DEFAULT_BRANCH"]` and `[]`. |
+| `rules` | list of objects | Each has a `type`; some have `parameters`. Unique by `type`. |
+| `bypass_actors` | list of objects | Each has `actor_id`, `actor_type`, `bypass_mode`. |
+
+### Validation (FR-012)
+
+- The key set is exactly the six above.
+- Exactly one rule has `type: required_status_checks`.
+- That rule's `parameters.required_status_checks` is a non-empty list, each entry an object with a
+  non-empty `context` string.
+- `target` is `branch`.
+
+The non-emptiness matters more than it looks: a file whose required-checks block is spelled wrong would
+leave the context gate iterating an empty list and passing, which is the green-without-judging failure
+this whole feature exists to prevent.
+
+### Not held
+
+`id`, `node_id`, `source`, `source_type`, `created_at`, `updated_at`, `_links`,
+`current_user_can_bypass`. All read-only. The live ruleset is projected onto the six writable fields
+before any comparison (R4).
+
+## Composed context
+
+Derived, never stored. What a ruleset or a consumer can require, computed by `tests/capabilities.py` from
+the workflows plus `published_surface.toml` (R6).
+
+| Field | Derived from |
+| --- | --- |
+| `context` | the calling job's `name` falling back to its id; then, where the job `uses:` a capability, ` / ` and that capability's `check_name` |
+| `workflow` | the workflow file the calling job is in |
+| `job` | the calling job's id |
+| `calls` | the capability the job calls, or none |
+| `cannot_judge` | why this context must not be required, or none |
+
+`cannot_judge` is set by whichever of these holds, and carries the reason as text (FR-010):
+
+| Condition | Reason carried |
+| --- | --- |
+| the called capability records a `skips_under` entry covering the called job | that entry's own `reason`, quoted |
+| the calling job carries an `if:` | the condition, verbatim |
+| the calling workflow declares no `pull_request` trigger | the events it does declare |
+
+A context with `cannot_judge` set may exist and may be advertised. It may not be required (FR-009).
+
+### The set today
+
+Eight contexts, three of them safe to require. The table in [spec.md](./spec.md#derivation) is the current reading; it
+is evidence, not a fixture, and no test asserts it — asserting it would be a fourth copy of what the
+workflows already say.
+
+## Apply verdict
+
+Produced by `actions/ruleset-decisions`, consumed by `.github/workflows/apply-ruleset.yml`. Never stored.
+
+| Field | Shape | Meaning |
+| --- | --- | --- |
+| `verdict` | `nothing` \| `create` \| `update` \| `refuse` | What the workflow should do next |
+| `ruleset-id` | string | The live ruleset to write to. Empty for `create` and `refuse`. |
+| `difference` | string | Field by field, both sides. Empty only for `nothing`. |
+| `body` | file path | The JSON to send. Written for `create` and `update`, absent otherwise. |
+| `message` | string | What was read, what it was compared against, what to do |
+
+State transitions, given a committed ruleset and the live rulesets:
+
+| Live state | Verdict |
+| --- | --- |
+| no ruleset carries the committed name | `create` |
+| exactly one does, and the projection matches | `nothing` |
+| exactly one does, and the projection differs | `update`, with `difference` populated |
+| more than one does | `refuse` (FR-007) |
+
+`update` is not permission to write: the workflow writes only when the dispatch has switched the dry run
+off (FR-004). A dry run reaching `update` prints the difference and stops, which is the whole of FR-005
+and R9.

--- a/specs/002-ruleset-in-tree/plan.md
+++ b/specs/002-ruleset-in-tree/plan.md
@@ -1,0 +1,148 @@
+# Implementation Plan: The Ruleset In The Tree
+
+**Branch**: `002-ruleset-in-tree` | **Date**: 2026-09-08 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/002-ruleset-in-tree/spec.md`
+
+## Summary
+
+Move the one fact nothing in the tree can see — what the default branch requires — into the tree, and put
+a gate on it.
+
+`.github/rulesets/protect-default-branch.json` becomes the owner of the required contexts.
+`tests/capabilities.py` learns to compose a check name from a calling job and a called capability, so a
+new test can assert every required context both resolves and is capable of judging. A dispatch-only
+workflow applies the file, dry by default, printing what it would change. The contents are unchanged from
+what is enforced today, so the first real dispatch is a no-op.
+
+## Technical Context
+
+**Language/Version**: Python 3.14, standard library only for anything a workflow runs. YAML reading in the
+suite uses `pyyaml`, already a dev dependency.
+
+**Primary Dependencies**: none added. `gh` (on the runner) for the two API calls;
+`actions/create-github-app-token` for the token, already used by `release-proposal.yml`.
+
+**Storage**: files in the tree. `.github/rulesets/*.json` is the new one.
+
+**Testing**: pytest, offline. The decision unit is imported and called; the ruleset and the workflows are
+read as structures.
+
+**Target Platform**: `ubuntu-latest` runners, and a maintainer's machine via `mise run ci`.
+
+**Project Type**: a repository of reusable GitHub Actions capabilities. This feature adds internal surface
+only — nothing here is published (FR-014).
+
+**Performance Goals**: none. The gate reads a handful of files; the workflow makes two API calls.
+
+**Constraints**: the suite must reach both verdicts with no network (FR-011). Applying must be reachable
+only by dispatch (FR-003). The enforced ruleset must not change (FR-013).
+
+**Scale/Scope**: one ruleset, eight composed contexts, three of them required.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Standing | Reading |
+| --- | --- | --- |
+| I — One owner per fact | **This feature exists to satisfy it** | The required contexts move from the settings UI into one file. The risk is introducing a *second* copy, which R1, R6 and R9 each turn down: the committed file holds only what a write accepts, the gate reads `published_surface.toml` rather than restating it, and no last-applied fingerprint is recorded. |
+| II — Secrets never persist | Pass | The App token is minted in the run and written nowhere. No ruleset field holds a secret. |
+| III — Gates are never loosened | **Watch** | R2 declines a `check-jsonschema` hook the conventions layer asks for. That is a convention, not a gate, and nothing is silenced: what the schema would have caught is asserted in the suite instead, and the departure is reported in R2 and in Complexity Tracking below. |
+| IV — What a consumer cannot absorb needs a new line | Pass | Nothing published changes. `apply-ruleset.yml` has no `workflow_call` trigger and `ruleset-decisions` is named by no capability, so no consumer can resolve either. R7 keeps both out of the release surface so neither moves a version. |
+| V — A published ref cannot be withdrawn | Pass | No tag, no ref, no release path touched. |
+| VI — Caller-controlled text never reaches a command line | **Load-bearing** | A ruleset name and a check context are text from a file, and the workflow holds an `administration: write` token. Every value reaches `rulesets.py` as an environment value or a file path, and every `gh api` body goes in through `--input`, never as an interpolated argument. `test_no_interpolation.py` already reads the action tree; this action is added to what it covers by being there. |
+| VII — A required gate never passes without judging | **This feature enforces it** | FR-009 is principle VII made structural: no context composed by a job that can skip may be required. The new test itself must not pass vacuously — hence FR-012, and hence the pre-flight below. |
+
+### Two gates this plan owes its own gate
+
+- **The composer must be pre-flighted.** A gate that reads a context out of a workflow reports green if it
+  reads nothing. The conventions layer already states the rule — pre-flight the line out of the file,
+  never a retyping of it — and `test_the_table_reader_finds_a_table_it_is_given` is the pattern to follow.
+  The composer is asserted against `ci.yml` by name: it must produce `ci / python-ci`, or the gate is
+  reading the wrong thing.
+- **`ci.yml`'s own required context is now named in the tree twice** — once composed from the workflow,
+  once required by the ruleset. That is the gate, not a duplication: one is derived, one is declared, and
+  the whole point is that they are compared.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-ruleset-in-tree/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── ruleset-decisions.md   # the internal action's contract
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+.github/
+├── rulesets/
+│   └── protect-default-branch.json   # NEW — the owner of what the default branch requires
+└── workflows/
+    └── apply-ruleset.yml             # NEW — dispatch only, dry by default
+
+actions/
+└── ruleset-decisions/                # NEW — internal, unpublished, stdlib only
+    ├── action.yml
+    └── rulesets.py
+
+tests/
+├── capabilities.py                   # EDIT — gains context composition and skip reasons
+├── conftest.py                       # EDIT — puts the new action on the path
+├── published_surface.toml            # EDIT — a row for ruleset-decisions, published = false
+├── test_ruleset_contexts.py          # NEW — FR-008, FR-009, FR-010, FR-012
+└── test_ruleset_decisions.py         # NEW — FR-002, FR-004, FR-005, FR-006, FR-007
+
+pyproject.toml                        # EDIT — pyright extraPaths, release exclude (R7)
+.pre-commit-config.yaml               # EDIT — check-json, from the hook repo already pinned
+docs/ai-instructions.md               # EDIT — the CI section's claim becomes false
+AGENTS.md                             # EDIT — a new layer 3 artefact needs its row
+README.md                             # CHECKED, no change expected — it describes what consumers
+                                      #   resolve, and nothing here is published (FR-014)
+```
+
+**Structure Decision**: no new top-level directory and no new Python home. The decision unit goes in
+`actions/`, which pyright, ruff, zizmor, `test_action_pins.py` and `test_no_interpolation.py` already
+cover — see R3. `.github/rulesets/` is a new directory but not a new file type: JSON is already in the
+tree, so `.editorconfig`, `.gitattributes` and `.gitignore` need nothing.
+
+## Implementation shape
+
+Sequenced so that each step is a green commit and the destructive one is last.
+
+1. **The committed ruleset, and the shape assertion.** `.github/rulesets/protect-default-branch.json`
+   reproducing the live ruleset field for field (R1, R10), plus the FR-012 assertions. Nothing reads the
+   required contexts yet, so this commit changes no verdict.
+2. **The composer.** `tests/capabilities.py` gains `composed_contexts()` and the skip reasons (R6), with
+   the pre-flight against `ci.yml`. Standalone and useful: it makes the eight contexts readable.
+3. **The gate.** `test_ruleset_contexts.py` — FR-008, FR-009, FR-010. This is the commit that would have
+   caught the `gates`→`ci` rename. Verify by renaming `ci.yml`'s job on a scratch commit and watching the
+   suite fail with the right message, then reverting.
+4. **The decision unit.** `actions/ruleset-decisions/` plus `test_ruleset_decisions.py`, both offline. The
+   unit answers `create` / `update` / `nothing` / `refuse`, renders the write body, and renders the
+   field-by-field difference. Nothing invokes it yet.
+5. **The applier.** `.github/workflows/apply-ruleset.yml`, plus the `published_surface.toml` row and the
+   pyproject edits from R7. Verified by dispatch in dry run, which must report nothing to change.
+6. **The documentation.** README, `docs/ai-instructions.md`, `AGENTS.md`. The instruction that a rename
+   must edit the ruleset now names the file that holds it; leaving the old framing standing would be the
+   stale-framing defect the conventions layer calls out.
+
+The first non-dry dispatch is deliberately **not** part of this feature's verification. It is a no-op by
+R10, and it is the one action here that no revert undoes.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --- | --- | --- |
+| No `check-jsonschema` hook for a new GitHub config file, against the conventions layer | The tool ships no schema for a repository ruleset and a remote one would put the network in `mise run ci`. What a schema would catch is asserted in the suite instead, where it can also catch the vacuous-pass case a schema could not | A vendored schema would be a second owner of a shape the API owns, and could not be checked against the API offline. `.github/actionlint.yaml` already sets the precedent for this exact case. See R2 |
+| A new composite action for logic one workflow calls | The conventions layer wants a decision callable rather than a `run:` block, and `actions/` is the only Python home this repository has wired | A `run:` block cannot be unit-tested offline; a new top-level directory would need two pyproject edits and would leave two Python homes. See R3 |

--- a/specs/002-ruleset-in-tree/quickstart.md
+++ b/specs/002-ruleset-in-tree/quickstart.md
@@ -1,0 +1,122 @@
+# Quickstart: The Ruleset In The Tree
+
+How to prove the feature works, and how to use it afterwards. Everything but the last section runs
+offline.
+
+## Prerequisites
+
+```bash
+mise run setup
+```
+
+## Read what the default branch requires
+
+One file, no API call, no visit to the settings UI — this is SC-002.
+
+```bash
+cat .github/rulesets/protect-default-branch.json
+```
+
+## Read what the tree composes
+
+Eight contexts, three of them safe to require. The composer is in `tests/capabilities.py`
+([R6](./research.md#r6--the-gates-two-halves)).
+
+```bash
+uv run python -c '
+import sys; sys.path.insert(0, "tests")
+from capabilities import composed_contexts
+for c in composed_contexts():
+    print(f"{c.context:36} {c.workflow:24} {c.cannot_judge or \"may be required\"}")
+'
+```
+
+## The gate, and proving it can fail
+
+`mise run ci` reaches every verdict with the network unavailable — SC-003.
+
+```bash
+mise run ci
+```
+
+Now prove the gate is not passing vacuously. Rename the job that composes a required context and watch it
+fail, which is exactly the change that went unnoticed in `001-consumer-contract`:
+
+```bash
+sed -i 's/^  ci:$/  gates:/' .github/workflows/ci.yml
+uv run pytest tests/test_ruleset_contexts.py
+git restore .github/workflows/ci.yml
+```
+
+Expected: a failure naming `ci / python-ci`, the workflow and job that no longer compose it, and that
+`.github/rulesets/protect-default-branch.json` must be edited in the same change. An exit code alone is
+not a result.
+
+Then prove the other half — a context that resolves but cannot judge (FR-009, principle VII):
+
+```bash
+# add "advisory / prek-advisory" to the required list, then:
+uv run pytest tests/test_ruleset_contexts.py
+```
+
+Expected: a failure quoting `prek-advisory`'s own recorded skip reason from
+`tests/published_surface.toml`. Undo the edit.
+
+## The decision unit
+
+Offline, no token, no network.
+
+```bash
+uv run pytest tests/test_ruleset_decisions.py
+```
+
+See [contracts/ruleset-decisions.md](./contracts/ruleset-decisions.md) for the inputs, outputs and the
+four verdicts.
+
+## Applying it
+
+Two dispatches, and the first writes nothing — SC-004, SC-005.
+
+```bash
+# 1. See what would change. Writes nothing.
+GH_TOKEN=$(gh auth token -u turboBasic) gh workflow run apply-ruleset.yml \
+  --repo turboBasic/github-actions-new
+
+# 2. Having read the difference, write it.
+GH_TOKEN=$(gh auth token -u turboBasic) gh workflow run apply-ruleset.yml \
+  --repo turboBasic/github-actions-new -f dry-run=false
+```
+
+On this feature's own first dispatch, expect **nothing to change** — the committed file reproduces the live
+ruleset field for field ([R10](./research.md#r10--what-the-first-apply-must-not-change)), which is FR-013
+and SC-006. A difference on the first dispatch means the committed file was transcribed wrong; read it
+before running step 2.
+
+## Compare against the live ruleset by hand
+
+If a dispatch reports something you did not expect, this is what it compared against:
+
+```bash
+GH_TOKEN=$(gh auth token -u turboBasic) gh api \
+  repos/turboBasic/github-actions-new/rulesets \
+  --jq '.[] | select(.name == "protect-default-branch") | .id' \
+  | xargs -I{} env GH_TOKEN=$(gh auth token -u turboBasic) gh api \
+      repos/turboBasic/github-actions-new/rulesets/{} \
+  | jq '{name, target, enforcement, conditions, rules, bypass_actors}'
+```
+
+The `jq` projection is the same six fields the comparison uses
+([R1](./research.md#r1--what-the-committed-file-holds)); everything else the API returns is read-only.
+
+## When a job is renamed
+
+The whole point of the feature. The rename and the ruleset edit are one change:
+
+1. Rename the calling job in `.github/workflows/*.yml`.
+2. Edit the context in `.github/rulesets/protect-default-branch.json`.
+3. The suite passes, so the pull request can merge.
+4. After it merges, dispatch apply — dry first — so GitHub stops requiring the retired name.
+
+Step 4 is still a human action. Nothing here applies on merge, because applying a wrong ruleset blocks
+every pull request in the repository including the one that would fix it
+([R9](./research.md#r9--why-there-is-no-drift-refusal), FR-003).

--- a/specs/002-ruleset-in-tree/quickstart.md
+++ b/specs/002-ruleset-in-tree/quickstart.md
@@ -19,7 +19,7 @@ cat .github/rulesets/protect-default-branch.json
 
 ## Read what the tree composes
 
-Nine contexts, three of them safe to require. The composer is in `tests/capabilities.py`
+Three of them are safe to require. The composer is in `tests/capabilities.py`
 ([R6](./research.md#r6--the-gates-two-halves)).
 
 ```bash
@@ -92,6 +92,15 @@ On this feature's own first dispatch, expect **nothing to change** — the commi
 ruleset field for field ([R10](./research.md#r10--what-the-first-apply-must-not-change)), which is FR-013
 and SC-006. A difference on the first dispatch means the committed file was transcribed wrong; read it
 before running step 2.
+
+## When GitHub stops matching the tree
+
+The same workflow runs on a weekly schedule over every file in `.github/rulesets/`. It reads and never
+writes — the write step is reachable from `workflow_dispatch` alone — and it fails on any difference,
+which is the alarm a hand edit in the UI would otherwise never raise. The fix is a dispatch: read the
+difference, then apply.
+
+A dispatch, by contrast, exits successfully on a difference. A difference is the reason to dispatch.
 
 ## Compare against the live ruleset by hand
 

--- a/specs/002-ruleset-in-tree/quickstart.md
+++ b/specs/002-ruleset-in-tree/quickstart.md
@@ -19,7 +19,7 @@ cat .github/rulesets/protect-default-branch.json
 
 ## Read what the tree composes
 
-Eight contexts, three of them safe to require. The composer is in `tests/capabilities.py`
+Nine contexts, three of them safe to require. The composer is in `tests/capabilities.py`
 ([R6](./research.md#r6--the-gates-two-halves)).
 
 ```bash
@@ -59,8 +59,9 @@ Then prove the other half — a context that resolves but cannot judge (FR-009, 
 uv run pytest tests/test_ruleset_contexts.py
 ```
 
-Expected: a failure quoting `prek-advisory`'s own recorded skip reason from
-`tests/published_surface.toml`. Undo the edit.
+Expected: a failure whose reason is `prek-advisory never judges what it names; the run may report
+success without checking anything` — set by `judges = false` in `tests/published_surface.toml`, not by
+its `skips_under` entry. Undo the edit.
 
 ## The decision unit
 
@@ -80,11 +81,11 @@ Two dispatches, and the first writes nothing — SC-004, SC-005.
 ```bash
 # 1. See what would change. Writes nothing.
 GH_TOKEN=$(gh auth token -u turboBasic) gh workflow run apply-ruleset.yml \
-  --repo turboBasic/github-actions-new
+  --repo turboBasic/github-actions-new -f ruleset=protect-default-branch
 
 # 2. Having read the difference, write it.
 GH_TOKEN=$(gh auth token -u turboBasic) gh workflow run apply-ruleset.yml \
-  --repo turboBasic/github-actions-new -f dry-run=false
+  --repo turboBasic/github-actions-new -f ruleset=protect-default-branch -f dry-run=false
 ```
 
 On this feature's own first dispatch, expect **nothing to change** — the committed file reproduces the live

--- a/specs/002-ruleset-in-tree/research.md
+++ b/specs/002-ruleset-in-tree/research.md
@@ -151,6 +151,13 @@ nothing is overwritten before the difference has been printed and read.
 drift could be attributed, rejected as a second owner of the ruleset's state — principle I, and the exact
 fork this feature exists to remove.
 
+**Amended**: the reasoning above holds for the *apply* path and only there. A scheduled read is a
+different question, and this decision did not answer it: on a dispatch a difference is the reason to run,
+but on a schedule a difference means GitHub stopped matching the tree with nobody watching. So the same
+workflow runs weekly over every committed ruleset, reads, and fails on any difference. It needs no
+attribution and records no state, so neither rejection above applies to it. Without it the tree is
+authoritative only while somebody remembers to dispatch, which is not a property a gate can rest on.
+
 ## R10 — What the first apply must not change
 
 **Decision**: the committed file reproduces the live ruleset exactly as read on 2026-09-08, including the

--- a/specs/002-ruleset-in-tree/research.md
+++ b/specs/002-ruleset-in-tree/research.md
@@ -1,0 +1,162 @@
+# Research: The Ruleset In The Tree
+
+Every decision below was reached against the tree as it stands, and each names the alternative it
+rejected. Nothing here is a preference: where a choice was settled by reading something, what was read
+is named.
+
+## R1 — What the committed file holds
+
+**Decision**: `.github/rulesets/protect-default-branch.json`, holding exactly the six fields a write
+accepts: `name`, `target`, `enforcement`, `bypass_actors`, `conditions`, `rules`.
+
+**Rationale**: `POST /repos/{owner}/{repo}/rulesets` and `PUT /repos/{owner}/{repo}/rulesets/{id}` take
+that body and no more. `id`, `node_id`, `source`, `source_type`, `created_at`, `updated_at`, `_links` and
+`current_user_can_bypass` come back on a read and are not settable. A file holding them would be a file
+whose every field cannot be honoured, and comparison would report drift on `updated_at` at every
+dispatch.
+
+**Alternatives**: committing the whole `GET` response, rejected for that reason. Writing it as YAML,
+rejected because the API speaks JSON and a translation layer would be a second owner of the shape.
+
+## R2 — No schema hook
+
+**Decision**: no `check-jsonschema` hook and no vendored schema. The committed ruleset's shape is
+asserted by the test suite instead — exactly the fields R1 names, a `required_status_checks` rule
+present, and a non-empty context list.
+
+**Rationale**: `check-jsonschema` 0.33 lists 27 builtin schemas and none is a repository ruleset. A
+`--schemafile <url>` would put the network into `mise run ci`, which the conventions layer forbids by
+name. `.github/actionlint.yaml` already carries this exact situation, and its own comment records the
+answer: no hook, reason in the file, because a mis-keyed entry there fails safe.
+
+This file does **not** fail safe in the same direction. A `required_status_checks` block spelled wrong
+would leave the FR-008 gate reading zero required contexts and passing on an empty set — a green gate
+that judged nothing, which is principle VII's failure inside the very feature meant to prevent it. So the
+shape is asserted where it can be, in the suite, and a hand-written schema would only restate what those
+assertions already hold.
+
+**Alternatives**: a vendored JSON Schema, rejected as a second owner of a shape the API owns and one this
+repository could not validate against the API offline anyway. No assertion at all, rejected because the
+vacuous pass above is the whole risk.
+
+**Reported**: the conventions layer says a new GitHub config file gets a `check-jsonschema` hook and a
+matching line in the `lint` task. This is a deliberate departure from that convention, on the precedent
+the convention's own exception already set. It is a convention rather than an invariant, and this is the
+report it asks for.
+
+## R3 — Where the apply logic lives
+
+**Decision**: `actions/ruleset-decisions/` — `action.yml` plus `rulesets.py`, composite, standard library
+only, every argument read from the environment. It is a pure decision unit: given the committed file and
+the live rulesets as JSON, it answers what to do and renders the body to write. All HTTP lives in
+`.github/workflows/apply-ruleset.yml`, which reads with `gh api` and writes with `gh api`.
+
+**Rationale**: this is the one pattern the repository already has for Python a workflow runs and pytest
+tests — `actions/release-decisions/`. Reusing it costs nothing: `tests/conftest.py` and pyproject's
+`[tool.pyright].extraPaths` already establish how such a module is reached, `[tool.ruff].src` already
+names `actions`, and `zizmor --pedantic .github/workflows actions` already covers the tree. Keeping the
+HTTP outside the unit is what makes the unit offline, which FR-011 requires.
+
+**Alternatives**: a `run:` block in the workflow, rejected because the conventions layer says moving a
+decision out of a `run:` block so it can be called is worth doing for that reason alone. A script under a
+new top-level directory, rejected: two pyproject edits and a second home for Python, for no gain. Putting
+it in `tests/`, rejected because apply logic is not test support.
+
+## R4 — Comparison by meaning
+
+**Decision**: normalise both sides, then compare. Project the live ruleset onto the fields R1 names; sort
+`rules` by `type`; sort `required_status_checks.required_status_checks` by `context`; sort `bypass_actors`
+by `(actor_type, actor_id)`; sort `conditions.ref_name.include` and `.exclude`. Report the difference
+field by field rather than as one blob.
+
+**Rationale**: a read orders lists as it pleases and fills defaults the file may omit. A byte comparison
+would report a difference at every dispatch, and a report that always fires is one nobody reads.
+
+**Alternatives**: comparing the serialised JSON, rejected for that reason.
+
+## R5 — Finding the ruleset
+
+**Decision**: match on `name` across `GET /repos/{owner}/{repo}/rulesets`, considering only entries whose
+`source_type` is `Repository`. More than one match refuses. None creates.
+
+**Rationale**: the API does not make names unique, and an organisation-level ruleset can carry the same
+name while not being ours to write. Guessing which one was meant is a write to the wrong object.
+
+## R6 — The gate's two halves
+
+**Decision**: `tests/capabilities.py` gains the composition, because it is already the one owner of how a
+workflow is read. For every workflow under `.github/workflows`, for every job: the calling half of the
+context is the job's `name` falling back to its id, and where the job's `uses:` names a capability in this
+repository, the context is `<calling half> / <check_name>` for each `check_name` that capability records
+in `published_surface.toml`. A job that calls nothing composes its own name alone.
+
+Alongside each context, why it cannot be required, where that applies: the called capability records a
+`skips_under` entry covering the called job; the calling job carries an `if:`; or the calling workflow
+declares no `pull_request` trigger.
+
+**Rationale**: `published_surface.toml` already owns every called job name and every skip reason, and
+this feature reads both and adds neither. The calling half is what nothing in the tree records today, and
+it is read from the workflow rather than restated anywhere.
+
+**Alternatives**: a second fixture listing composed contexts, rejected — it would be a third copy of a
+fact the workflows and `published_surface.toml` already hold between them.
+
+## R7 — Release relevance
+
+**Decision**: `.github/workflows/apply-ruleset.yml` and `actions/ruleset-decisions/action.yml` join
+`[tool.turbobasic-release].exclude` in `pyproject.toml`.
+
+**Rationale**: `include` is `.github/workflows` and `actions`, so without this every edit to either would
+read as a consumer-visible change and move a version for nobody's benefit. Nothing outside this repository
+can call either — the workflow has no `workflow_call` trigger and the action is named by no capability.
+This is the same reason every one of this repository's own caller workflows is already excluded.
+
+**Open for the task list**: whether `matches()` in `decisions.py` needs a directory glob
+(`actions/ruleset-decisions/*`) or the single `action.yml` path suffices. Read the matcher, do not assume.
+
+## R8 — The token
+
+**Decision**: the apply workflow mints an App installation token with
+`actions/create-github-app-token`, narrowed to `permission-administration: write`, from the
+`RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY` secrets — the pattern `release-proposal.yml` already
+uses. The run's own `GITHUB_TOKEN` gets `contents: read`, for the checkout and nothing else.
+
+**Rationale**: `GITHUB_TOKEN` cannot administer a ruleset at any permission level, so an App token is not
+a preference here. Minting it narrowed means the run holds administration rights and nothing else.
+
+**Verified as far as it can be**: those two secrets are the only App credentials on the repository. Whether
+that App's installation actually grants `administration` could not be read from outside it — both
+`/repos/{owner}/{repo}/installation` and `/users/{owner}/installations` require App authentication. The
+mint itself is the check: `create-github-app-token` fails when the installation cannot grant a permission
+it is asked for, and it fails before any write. If it does fail, the App's installed permissions are what
+to widen, and the issue's claim that `turbobasic-repo-automation` holds `administration: write` is what to
+re-read.
+
+## R9 — Why there is no drift refusal
+
+**Decision**: one dispatch input, the dry run, defaulting on. No second `force` input.
+
+**Rationale**: two readings of the spec's own requirements collided. A refusal on any difference between
+live and committed would fire on every dispatch that did any work, because a difference is the only reason
+to dispatch — and a refusal that always fires is not read. Refusing only a difference a *person* made in
+the UI would be the useful rule, and it needs the ruleset's history to name who made each edit.
+`GET /repos/turboBasic/github-actions-new/rulesets/22481092/history` returns two versions and `actor` is
+`null` on both. So attribution is not available, and what is left is to show the difference and require a
+person to act on it.
+
+That is the dry run, and it is the whole mechanism: nothing is written by a dispatch at its defaults, so
+nothing is overwritten before the difference has been printed and read.
+
+**Alternatives**: keeping both inputs, rejected above. Recording the last-applied state in the tree so
+drift could be attributed, rejected as a second owner of the ruleset's state — principle I, and the exact
+fork this feature exists to remove.
+
+## R10 — What the first apply must not change
+
+**Decision**: the committed file reproduces the live ruleset exactly as read on 2026-09-08, including the
+`admin` bypass actor and the three required contexts. The first real dispatch is expected to report
+nothing to change.
+
+**Rationale**: FR-013 and SC-006. A feature that moved ownership and edited the contents in one change
+would leave nobody able to say which half caused a later block, and applying is the one action here that
+no revert undoes.

--- a/specs/002-ruleset-in-tree/spec.md
+++ b/specs/002-ruleset-in-tree/spec.md
@@ -1,0 +1,250 @@
+# Feature Specification: The Ruleset In The Tree
+
+**Feature Branch**: `002-ruleset-in-tree`
+
+**Created**: 2026-09-08
+
+**Status**: Draft
+
+**Input**: Issue #6 — "codify the branch ruleset so a retired check name cannot pass unnoticed"
+
+## Derivation
+
+Every statement below was read from one of: this repository's live `protect-default-branch` ruleset,
+`.github/workflows/*.yml`, `tests/published_surface.toml`, `tests/capabilities.py`, `mise.toml`,
+`.pre-commit-config.yaml`, or `docs/ai-instructions.md`.
+
+The live ruleset, at the time of writing:
+
+| Field | Value |
+| --- | --- |
+| target | `branch`, including `~DEFAULT_BRANCH`, excluding nothing |
+| enforcement | `active` |
+| rules | `deletion`, `non_fast_forward`, `required_linear_history`, `required_status_checks` |
+| required contexts | `ci / python-ci`, `commits / pr-title`, `commits / commit-messages` |
+| strict policy | off |
+| bypass actors | repository role 5 (admin), `always` |
+
+What composes a context is two halves. The second half is a called workflow's job name, which
+`published_surface.toml` already owns as `check_name`. The first half is the calling job's name in one
+of *this* repository's own workflows, falling back to its id — which nothing in the tree records at
+all, and which no test reads.
+
+The full set the tree currently composes:
+
+| Composed context | Composed by | Safe to require |
+| --- | --- | --- |
+| `ci / python-ci` | `ci.yml` job `ci` | yes |
+| `commits / pr-title` | `commit-messages.yml` job `commits` | yes |
+| `commits / commit-messages` | `commit-messages.yml` job `commits` | yes |
+| `advisory / prek-advisory` | `advisory.yml` job `advisory` | no — advertised as advisory |
+| `describe / pr-description` | `describe-pr.yml` job `describe` | no — writes rather than judges |
+| `release-on-merge / python-ci` | `release-on-merge.yml` job `verify` | no — never fires on a pull request |
+| `release-on-merge / tag-and-publish` | `release-on-merge.yml` job `release` | no — never fires on a pull request |
+| `propose` | `release-proposal.yml` job `propose` | no — never fires on a pull request |
+
+The gap this feature closes: renaming a calling job, retiring a workflow, or making a job conditional
+changes what reports, and the ruleset goes on naming what no longer exists. A required context that
+never reports blocks every pull request in the repository, produces no failure and no annotation, and
+is diagnosable only by opening the ruleset in the UI. `e4507ed` wrote the instruction that the same
+change must edit the ruleset; this feature is the gate, because the instruction was already there when
+`001-consumer-contract` renamed `ci.yml`'s job and the ruleset kept requiring the old name for six
+commits.
+
+## Decisions
+
+Settled before this spec was written, and recorded here rather than re-opened:
+
+- **Applying runs on `workflow_dispatch` only.** Applying a ruleset is not reversible by revert: a
+  wrong one blocks every pull request in the repository, including the one that would fix it. A human
+  presses the button. What runs on every pull request is the offline gate.
+- **A ruleset edited by hand is never silently overwritten.** Applying is a dry run unless asked
+  otherwise: the dispatch prints what it would change to the live ruleset and writes nothing. Writing
+  for real is a second dispatch with the dry run switched off, made after the difference has been read.
+  An emergency edit in the UI is a deliberate act, and discarding it silently would be worse than the
+  drift it caused.
+
+  A refusal on any difference was considered and rejected: a difference is the only reason to apply, so
+  such a refusal would fire on every run that did any work, and one that always fires stops being read.
+  Attributing the difference instead — refusing only a difference a person made in the UI — needs the
+  ruleset's edit history to name who made it, and this repository's history returns `actor` as `null`.
+  What is left is to show the difference and make a person act on it, which is the dry run.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The ruleset has one owner (Priority: P1)
+
+A maintainer changes what the default branch requires by editing a file in the tree and opening a pull
+request. After it merges, they dispatch the apply workflow and GitHub matches the tree.
+
+**Why this priority**: Nothing else in this feature is legitimate without it. A committed copy of the
+ruleset that GitHub is not applied from is two copies of one fact, which drift and afterwards neither
+says which was current — the exact arrangement principle I forbids. The gate in Story 2 reads the
+committed copy, so the committed copy has to be the one that governs.
+
+**Independent Test**: Edit the committed ruleset, dispatch the apply workflow, then read the ruleset
+back from GitHub and see the edit. Delivers a ruleset that is reviewable in a diff.
+
+**Acceptance Scenarios**:
+
+1. **Given** the committed ruleset and the live ruleset agree, **When** apply is dispatched, **Then**
+   it reports that there was nothing to change and exits successfully, whether or not it is a dry run.
+2. **Given** the committed ruleset has been edited on the default branch, **When** apply is dispatched
+   at its default, **Then** it prints every field that differs, on both sides, and writes nothing.
+3. **Given** that difference has been read, **When** apply is dispatched with the dry run switched off,
+   **Then** the live ruleset afterwards matches the committed one in every field the committed file
+   declares.
+4. **Given** no ruleset of that name exists on the repository, **When** apply is dispatched with the dry
+   run switched off, **Then** it creates one from the committed file.
+
+---
+
+### User Story 2 - A retired context fails the pull request (Priority: P2)
+
+A maintainer renames a calling job, removes a workflow, or makes a job conditional. The pull request
+that does it fails, naming the required context that would stop reporting and what to do about it.
+
+**Why this priority**: This is why the issue was opened. It is P2 only because it reads what Story 1
+commits.
+
+**Independent Test**: On a branch, rename `ci.yml`'s job from `ci` to anything else and run the suite
+offline. It fails naming `ci / python-ci`. Delivers the gate that makes the rename impossible to land
+by accident.
+
+**Acceptance Scenarios**:
+
+1. **Given** every required context is composed by the tree, **When** the suite runs, **Then** it
+   passes, with no network access.
+2. **Given** a calling job has been renamed, **When** the suite runs, **Then** it fails naming the
+   required context that no longer resolves, the workflow and job that used to compose it, and that the
+   committed ruleset must be edited in the same change.
+3. **Given** a required context names a called job that is not in `published_surface.toml`, **When** the
+   suite runs, **Then** it fails — the two halves of the context are checked, not just the first.
+4. **Given** the tree composes a context that the ruleset does not require, **When** the suite runs,
+   **Then** it passes. Not every check is a gate, and requiring more is the maintainer's decision, not
+   the gate's.
+
+---
+
+### User Story 3 - A gate that cannot judge is never required (Priority: P3)
+
+A maintainer adds a context to the required list that would report green without judging anything. The
+pull request fails.
+
+**Why this priority**: Principle VII's failure mode, reachable by the same one-word edit this feature
+exists to catch, and the required list is now the place where such an edit is visible. Separated from
+Story 2 because Story 2's gate is useful without it.
+
+**Independent Test**: Add `advisory / prek-advisory` to the committed required list and run the suite
+offline. It fails. Delivers the half of the check that a resolvable name does not cover.
+
+**Acceptance Scenarios**:
+
+1. **Given** a required context whose called capability declares a `skips_under` entry for its job,
+   **When** the suite runs, **Then** it fails, quoting the recorded reason for the skip.
+2. **Given** a required context composed by a workflow that has no `pull_request` trigger, **When** the
+   suite runs, **Then** it fails — it cannot report on the event the ruleset gates.
+3. **Given** a required context composed by a job carrying an `if:`, **When** the suite runs, **Then**
+   it fails.
+
+---
+
+### Edge Cases
+
+- **The API returns fields nobody can set.** `id`, `node_id`, `created_at`, `updated_at`, `source`,
+  `source_type`, `_links` and `current_user_can_bypass` come back on a read and are rejected or ignored
+  on a write. The committed file holds only what a write accepts, and comparison is over that shape
+  alone — otherwise every apply reports drift.
+- **Field order and absent fields.** A ruleset read back may order rules differently and may fill
+  defaults the committed file omits. Comparison is by meaning, not by byte, or the refusal fires on
+  every dispatch and stops meaning anything.
+- **Two rulesets share a name.** Names are not unique on the API. Applying must refuse rather than
+  guess which one it meant.
+- **The apply workflow's own context.** It never fires on a pull request, so it can never be required —
+  and it must not appear in the committed required list. Story 3's second scenario already covers this.
+- **A calling job that declares a `name:`.** The composed context uses the name, not the id. None do
+  today; the gate must not assume it.
+- **The ruleset is applied while a pull request is open.** Out of scope: GitHub re-evaluates on its own,
+  and nothing here can order it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The branch ruleset MUST exist as committed configuration under `.github/rulesets/`, one
+  file per ruleset, holding every field a write accepts.
+- **FR-002**: A workflow MUST apply a committed ruleset to the repository, creating it when absent and
+  updating it when present.
+- **FR-003**: Applying MUST be reachable only by `workflow_dispatch`, and never by a push, a merge, a
+  schedule or a pull request.
+- **FR-004**: Applying MUST default to a dry run, and MUST write only when the dispatch switches the dry
+  run off. One input governs this; there is no second one.
+- **FR-005**: Applying MUST print every field in which the live ruleset differs from the committed one,
+  showing both sides, before it writes and whether or not it writes.
+- **FR-006**: Applying MUST report that there was nothing to change, and exit successfully, when the two
+  already agree.
+- **FR-007**: Applying MUST refuse when more than one ruleset on the repository carries the committed
+  name.
+- **FR-008**: The test suite MUST assert that every required context in every committed ruleset is
+  composed by this repository's own workflows, resolving both halves — the calling job's name and the
+  called capability's job name as `published_surface.toml` records it.
+- **FR-009**: The test suite MUST assert that no required context is composed by a job that can skip:
+  one whose capability records a `skips_under` entry covering it, one carrying an `if:`, or one in a
+  workflow with no `pull_request` trigger.
+- **FR-010**: A failure from FR-008 or FR-009 MUST name the context, where it is required, what
+  composes it or fails to, and what a maintainer should change.
+- **FR-011**: The test suite MUST reach both verdicts without network access.
+- **FR-012**: A committed ruleset's shape MUST be asserted offline: exactly the fields a write accepts,
+  a required-status-checks rule present, and a non-empty context list. A malformed file MUST fail rather
+  than leave the FR-008 gate reading no contexts and passing.
+- **FR-013**: The committed ruleset MUST reproduce the live one as read at the time of writing, so this
+  feature changes what is enforced in no way at all.
+- **FR-014**: The apply workflow MUST NOT be a published capability. Nothing outside this repository
+  calls it.
+
+### Key Entities
+
+- **Committed ruleset**: a file under `.github/rulesets/` naming the branches it targets, its
+  enforcement, its rules, its required contexts and its bypass actors. The single owner of what the
+  default branch requires.
+- **Composed context**: a check name a consumer or a ruleset can require, being a calling job's name
+  and, where that job calls a capability, the called job's name after it.
+- **Published surface**: `tests/published_surface.toml`, already the owner of every capability's
+  `check_name` and `skips_under`. This feature reads it and adds nothing to it.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Renaming any job that composes a required context fails the pull request that does it,
+  before review.
+- **SC-002**: What the default branch requires is answerable by reading one file in the tree, with no
+  API call and no visit to the settings UI.
+- **SC-003**: `mise run ci` reaches both verdicts with the network unavailable.
+- **SC-004**: Bringing GitHub back into agreement with the tree is two dispatches and no hand edit in the
+  UI — one that shows the difference, one that writes it.
+- **SC-005**: A ruleset edited by hand is reported rather than lost: no dispatch at its defaults writes
+  anything, so nothing is overwritten before a maintainer has read the difference.
+- **SC-006**: The enforced ruleset is unchanged by this feature — the same contexts are required before
+  and after.
+
+## Assumptions
+
+- `turbobasic-repo-automation` already holds `administration: write`, so no new token, App or secret is
+  created. The apply workflow uses it.
+- The `admin` bypass actor on the live ruleset stays. It is what let the retired context be diagnosed at
+  all, and removing it is a separate decision.
+- Only `protect-default-branch` is codified. This repository has one ruleset and organisation-level
+  rulesets are not ours to write.
+- `published_surface.toml` is authoritative for called job names and needs no new field. If the plan
+  finds it does, that is a change to a file whose whole purpose is to arrive as a deliberate diff, and
+  is called out there.
+- `check-jsonschema` ships no builtin schema for a repository ruleset, and a `--schemafile <url>` would
+  put the network in `mise run ci`. FR-012 therefore says what must be asserted rather than which tool
+  asserts it. `.github/actionlint.yaml` is the standing precedent for a GitHub config file with no
+  builtin schema, and the plan records why this one is not simply left the same way.
+- Publishing this as a capability for consumers is explicitly out of scope. Every consumer has the same
+  exposure, and the issue says so; this feature earns the right to that conversation by working here
+  first.
+- Required contexts on branches other than the default are out of scope, as the live ruleset targets
+  only `~DEFAULT_BRANCH`.

--- a/specs/002-ruleset-in-tree/spec.md
+++ b/specs/002-ruleset-in-tree/spec.md
@@ -39,7 +39,7 @@ The full set the tree currently composes:
 | `commits / commit-messages` | `commit-messages.yml` job `commits` | yes |
 | `advisory / prek-advisory` | `advisory.yml` job `advisory` | no — advertised as advisory |
 | `describe / pr-description` | `describe-pr.yml` job `describe` | no — writes rather than judges |
-| `release-on-merge / python-ci` | `release-on-merge.yml` job `verify` | no — never fires on a pull request |
+| `verify / python-ci` | `release-on-merge.yml` job `verify` | no — never fires on a pull request |
 | `release-on-merge / tag-and-publish` | `release-on-merge.yml` job `release` | no — never fires on a pull request |
 | `propose` | `release-proposal.yml` job `propose` | no — never fires on a pull request |
 

--- a/specs/002-ruleset-in-tree/spec.md
+++ b/specs/002-ruleset-in-tree/spec.md
@@ -40,7 +40,7 @@ The full set the tree currently composes:
 | `advisory / prek-advisory` | `advisory.yml` job `advisory` | no — advertised as advisory |
 | `describe / pr-description` | `describe-pr.yml` job `describe` | no — writes rather than judges |
 | `verify / python-ci` | `release-on-merge.yml` job `verify` | no — never fires on a pull request |
-| `release-on-merge / tag-and-publish` | `release-on-merge.yml` job `release` | no — never fires on a pull request |
+| `release / tag-and-publish` | `release-on-merge.yml` job `release` | no — never fires on a pull request |
 | `propose` | `release-proposal.yml` job `propose` | no — never fires on a pull request |
 
 The gap this feature closes: renaming a calling job, retiring a workflow, or making a job conditional
@@ -140,8 +140,9 @@ offline. It fails. Delivers the half of the check that a resolvable name does no
 
 **Acceptance Scenarios**:
 
-1. **Given** a required context whose called capability declares a `skips_under` entry for its job,
-   **When** the suite runs, **Then** it fails, quoting the recorded reason for the skip.
+1. **Given** a required context whose called capability is marked `judges = false` — it goes green
+   without a pass/fail verdict on what it names — **When** the suite runs, **Then** it fails, naming the
+   capability.
 2. **Given** a required context composed by a workflow that has no `pull_request` trigger, **When** the
    suite runs, **Then** it fails — it cannot report on the event the ruleset gates.
 3. **Given** a required context composed by a job carrying an `if:`, **When** the suite runs, **Then**
@@ -188,9 +189,12 @@ offline. It fails. Delivers the half of the check that a resolvable name does no
 - **FR-008**: The test suite MUST assert that every required context in every committed ruleset is
   composed by this repository's own workflows, resolving both halves — the calling job's name and the
   called capability's job name as `published_surface.toml` records it.
-- **FR-009**: The test suite MUST assert that no required context is composed by a job that can skip:
-  one whose capability records a `skips_under` entry covering it, one carrying an `if:`, or one in a
-  workflow with no `pull_request` trigger.
+- **FR-009**: The test suite MUST assert that no required context is composed by a job that cannot
+  produce a pass/fail verdict on what it names: one whose capability is marked `judges = false` in
+  `published_surface.toml`, one carrying an `if:`, or one in a workflow with no `pull_request` trigger.
+  A capability's `skips_under` entry records a narrower fact — that its job's own `if:` can skip it
+  under some event — and does not by itself disqualify a context: whether that entry's event is ever
+  reached depends on which workflow calls it.
 - **FR-010**: A failure from FR-008 or FR-009 MUST name the context, where it is required, what
   composes it or fails to, and what a maintainer should change.
 - **FR-011**: The test suite MUST reach both verdicts without network access.

--- a/specs/002-ruleset-in-tree/tasks.md
+++ b/specs/002-ruleset-in-tree/tasks.md
@@ -1,0 +1,348 @@
+---
+
+description: "Task list for 002-ruleset-in-tree"
+---
+
+# Tasks: The Ruleset In The Tree
+
+**Input**: Design documents from `/specs/002-ruleset-in-tree/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md),
+[data-model.md](./data-model.md), [contracts/ruleset-decisions.md](./contracts/ruleset-decisions.md)
+
+**Tests**: included, and not optionally. The gate *is* the deliverable — FR-008 to FR-012 are all
+assertions, and User Stories 2 and 3 have no product other than a failing suite.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel — different files, no dependency on an unfinished task
+- **[Story]**: US1, US2, US3 as numbered in [spec.md](./spec.md)
+- Paths are repository-relative
+
+## Path conventions
+
+No `src/`. This repository's Python lives in `actions/<name>/` for anything a workflow runs and in
+`tests/` for the suite — see [R3](./research.md#r3--where-the-apply-logic-lives). Nothing here introduces
+a third location.
+
+## Standing constraints
+
+Every task below is subject to these. They are gates already in the tree, and each has bitten a change
+of this shape before:
+
+- **`test_no_run_block_interpolates_caller_controlled_text`** reads every `run:` in
+  `.github/workflows/*.yml` **and** `actions/*/action.yml`, and forbids `inputs` among others. A `run:`
+  in either file passes values through `env:`. An `if:` may read `inputs` — only `run:` is scanned.
+- **`test_no_secret_reaches_anything_but_a_step_input`** allows `secrets.*` only inside a step's `with:`.
+- **`test_every_permission_carries_its_reason_beside_it`** matches any line of the form
+  `<lower-kebab>: read|write|none`, which includes `permission-administration: write` in a
+  `create-github-app-token` `with:` block. Every such line carries `# reason` on the same line.
+- **`custom.github-workflows-require-timeout`** requires `timeout-minutes` on every job.
+- **`test_every_third_party_reference_is_pinned_to_a_full_sha`** — a full SHA with a `# vN` comment.
+  `$/` names this repository and takes no ref.
+- **No docstrings, no multi-line comment blocks.** Comments only where the WHY is non-obvious.
+- Run `mise run ci` before each commit. Conventional Commits subject.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: put the live ruleset in the tree, byte-checked, before anything reads it.
+
+- [X] T001 Create `.github/rulesets/protect-default-branch.json` holding exactly the six writable fields
+      from [R1](./research.md#r1--what-the-committed-file-holds) — `name`, `target`, `enforcement`,
+      `conditions`, `rules`, `bypass_actors` — transcribed from the live ruleset, not retyped:
+
+      ```bash
+      GH_TOKEN=$(gh auth token -u turboBasic) gh api \
+        repos/turboBasic/github-actions-new/rulesets/22481092 \
+        | jq '{name, target, enforcement, conditions, rules, bypass_actors}' \
+        > .github/rulesets/protect-default-branch.json
+      ```
+
+- [X] T002 Prove T001 is faithful: re-read the live ruleset, project it the same way, and diff against
+      `.github/rulesets/protect-default-branch.json` with `jq -S`. A difference here means the
+      transcription is wrong, and
+      [FR-013](./spec.md#functional-requirements) and SC-006 both hang on it being exact.
+- [X] T003 [P] Add `- id: check-json` to the `pre-commit/pre-commit-hooks` block in
+      `.pre-commit-config.yaml` (rev `v6.0.0`, already pinned). Then run `mise exec -- prek run --all-files`
+      and confirm it does not claim `.markdownlint-cli2.jsonc`; if `identify` tags JSONC as JSON, add an
+      `exclude:` for it with the reason on the line above. This is syntax only, and deliberately not a
+      schema — see T006.
+
+**Checkpoint**: the ruleset is in the tree and reproducible from the API. Nothing reads it yet, so no
+verdict has changed.
+
+---
+
+## Phase 2: Foundational (blocking prerequisites)
+
+**Purpose**: the loader and the shape assertions. Both stories read the committed file, and a malformed
+file would make each of their gates pass on an empty set — which is the very failure this feature exists
+to prevent, reappearing inside it.
+
+**⚠️ No user story work begins until this phase is complete.**
+
+- [ ] T004 In `tests/capabilities.py` — already the one owner of how a workflow is read — add
+      `RULESET_DIR = REPO / ".github" / "rulesets"`, `ruleset_docs() -> dict[str, Doc]` keyed by file stem,
+      `WRITABLE_FIELDS`, and `required_contexts(doc) -> list[str]` reading
+      `rules[type == required_status_checks].parameters.required_status_checks[].context`. Full type hints;
+      `json.loads`, not a new dependency.
+- [ ] T005 In `tests/test_ruleset_contexts.py` (new), the [FR-012](./spec.md#functional-requirements)
+      assertions from [data-model.md](./data-model.md#validation-fr-012): the key set is exactly
+      `WRITABLE_FIELDS`; exactly one rule is `required_status_checks`; its context list is non-empty and
+      every entry has a non-empty `context`; `target` is `branch`.
+- [ ] T006 In the same file, record beside those assertions why there is no `check-jsonschema` hook —
+      [R2](./research.md#r2--no-schema-hook) in two or three lines, stating the rule and not the history:
+      the tool ships no ruleset schema, a remote one would put the network in `mise run ci`, and unlike
+      `.github/actionlint.yaml` a mis-keyed field here fails *green* rather than safe. JSON carries no
+      comments, so this is the only place the reason can live next to what enforces it.
+- [ ] T007 Pre-flight `required_contexts()` against a literal built in the test, per the conventions
+      layer: a reader that silently stops matching reports green over a file full of retired names. Assert
+      it finds a context it is given, and returns `[]` for a ruleset with no such rule.
+
+**Checkpoint**: `mise run ci` green. A malformed ruleset now fails; a correct one asserts nothing yet.
+
+---
+
+## Phase 3: User Story 1 — The ruleset has one owner (Priority: P1)
+
+**Goal**: what the default branch requires is edited in the tree and applied from it, so the committed
+file is the fact rather than a copy of one.
+
+**Independent Test**: edit the committed ruleset, dispatch in dry run, and see the difference printed with
+nothing written; dispatch again with the dry run off and read the change back from GitHub.
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] `actions/ruleset-decisions/rulesets.py` — the decision unit from
+      [contracts/ruleset-decisions.md](./contracts/ruleset-decisions.md). Standard library only, every
+      argument from the environment (`COMMITTED`, `LIVE`, `BODY_PATH`), nothing written outside
+      `BODY_PATH`. Normalise per [R4](./research.md#r4--comparison-by-meaning); select the live match per
+      [R5](./research.md#r5--finding-the-ruleset); emit `verdict`, `ruleset-id`, `difference`, `body`,
+      `message` to `GITHUB_OUTPUT`. Mirror `actions/release-decisions/decisions.py` for shape.
+- [ ] T009 [US1] Every failure message names what was read, what it was compared against, and what to do
+      about it — the four rows in
+      [the contract's failure table](./contracts/ruleset-decisions.md#failure-messages). A malformed
+      committed file is a `refuse` verdict, not a traceback.
+- [ ] T010 [P] [US1] `actions/ruleset-decisions/action.yml` — composite, inputs `committed`, `live`,
+      `body-path`; outputs as above; one step passing every value through `env:` and running
+      `python3 "$GITHUB_ACTION_PATH/rulesets.py"`. Copy the env-only discipline from
+      `actions/release-decisions/action.yml` — principle VI, and `test_no_interpolation.py` reads this
+      file.
+- [ ] T011 [P] [US1] `tests/conftest.py` — insert `actions/ruleset-decisions` on `sys.path` beside the
+      existing entry, with the same reason it already carries: a hyphen in the directory name means it is
+      not importable as a package.
+- [ ] T012 [US1] `pyproject.toml` — add `actions/ruleset-decisions` to `[tool.pyright].extraPaths`, and
+      add `actions/ruleset-decisions` to `[tool.turbobasic-release].exclude` per
+      [R7](./research.md#r7--release-relevance). The open question there is settled: `matches()` in
+      `decisions.py` tries `fnmatch(path, f"{pattern}/*")`, so the bare directory covers both files and no
+      glob is needed. Keep the exclude list sorted as it is.
+- [ ] T013 [US1] `tests/published_surface.toml` — a row for `ruleset-decisions`: `kind = "action"`,
+      `published = false`, empty `inputs`, `permissions`, `tool_prerequisites` and `skips_under`, mirroring
+      `release-decisions`. Without it `test_every_capability_in_the_tree_is_in_the_fixture` fails, which is
+      the gate working.
+- [ ] T014 [US1] `tests/test_ruleset_decisions.py` — the four verdicts from
+      [data-model.md](./data-model.md#apply-verdict): `create` when no live ruleset carries the name,
+      `nothing` when the projection matches, `update` with a populated `difference` when it does not,
+      `refuse` when two rulesets share the name ([FR-007](./spec.md#functional-requirements)). Plus: a live
+      ruleset carrying `updated_at` and `_links` still reads as `nothing`, and reordered `rules` and
+      `required_status_checks` still read as `nothing` — R4's whole point. Offline; the live side is a
+      fixture built in the test.
+- [ ] T015 [US1] `.github/workflows/apply-ruleset.yml` — `workflow_dispatch` only
+      ([FR-003](./spec.md#functional-requirements)), inputs `ruleset` and `dry-run` with `dry-run`
+      defaulting to `true` (FR-004, [R9](./research.md#r9--why-there-is-no-drift-refusal)); one job with
+      `timeout-minutes`; `contents: read` on the run's token for the checkout; an App token from
+      `actions/create-github-app-token` narrowed to `permission-administration: write`
+      ([R8](./research.md#r8--the-token)), following `release-proposal.yml`. Reads with
+      `gh api repos/$GH_REPO/rulesets` into `$RUNNER_TEMP/live.json`, calls
+      `uses: $/actions/ruleset-decisions`, prints the difference unconditionally (FR-005), and writes with
+      `gh api --input "$body"` only when the verdict is `create` or `update` **and** the dry run is off.
+      Never a body as an argument. Every permission line carries its reason.
+- [ ] T016 [US1] Add `.github/workflows/apply-ruleset.yml` to `[tool.turbobasic-release].exclude` in
+      `pyproject.toml` — same reason as T012, and the same reason every other caller workflow of this
+      repository is already listed there.
+- [ ] T017 [US1] Verify by dispatch, in dry run, after the branch has merged:
+      `gh workflow run apply-ruleset.yml`. Expect **nothing to change**
+      ([R10](./research.md#r10--what-the-first-apply-must-not-change)). A difference means T001 was
+      transcribed wrong — read it and do not proceed to a real dispatch.
+
+**Checkpoint**: applying works and is a no-op. Nothing has been written to GitHub.
+
+---
+
+## Phase 4: User Story 2 — A retired context fails the pull request (Priority: P2)
+
+**Goal**: renaming a calling job, retiring a workflow or making a job conditional fails the pull request
+that does it, naming what would stop reporting.
+
+**Independent Test**: rename `ci.yml`'s job and watch `tests/test_ruleset_contexts.py` fail naming
+`ci / python-ci`; restore it and watch the suite pass.
+
+### Implementation for User Story 2
+
+- [ ] T018 [US2] In `tests/capabilities.py`, add the composer from
+      [R6](./research.md#r6--the-gates-two-halves): for every workflow under `.github/workflows`, for every
+      job, the calling half is the job's `name` falling back to its id; where `uses:` names a capability in
+      this repository, one context per `check_name` that capability records in `published_surface.toml`,
+      spelled `<calling half> / <called job>`. A job calling nothing composes its own name alone. Return a
+      `NamedTuple` carrying the fields in
+      [data-model.md](./data-model.md#composed-context) so a failure can name provenance.
+- [ ] T019 [US2] Pre-flight the composer against the tree by name: it must produce `ci / python-ci` from
+      `ci.yml`, both `commits / pr-title` and `commits / commit-messages` from `commit-messages.yml`, and
+      `propose` from `release-proposal.yml`. This is the gate on the gate — a composer that stops reading
+      `uses:` would otherwise report green over every retired name at once.
+- [ ] T020 [US2] In `tests/test_ruleset_contexts.py`, [FR-008](./spec.md#functional-requirements): every
+      required context in every committed ruleset is composed by the tree. Both halves — a context naming a
+      called job that `published_surface.toml` does not record fails too.
+- [ ] T021 [US2] [FR-010](./spec.md#functional-requirements): the failure names the context, where it is
+      required, what composes it or fails to, and that the committed ruleset must be edited in the same
+      change. Assert the message content, not only the failure — a gate whose message says nothing is an
+      exit code, and the conventions layer says that is not a result.
+- [ ] T022 [US2] Assert the deliberate non-failure: a context the tree composes but the ruleset does not
+      require passes. Requiring more is a maintainer's decision and not this gate's
+      ([spec.md Story 2, scenario 4](./spec.md#user-story-2---a-retired-context-fails-the-pull-request-priority-p2)).
+- [ ] T023 [US2] Prove it can fail. Rename `ci.yml`'s job `ci` to `gates`, run
+      `uv run pytest tests/test_ruleset_contexts.py`, read the message, restore the file. This is the exact
+      change that went unnoticed for six commits in `001-consumer-contract`; if the suite passes, the gate
+      is reading the wrong thing.
+
+**Checkpoint**: the rename that opened issue #6 is now impossible to land.
+
+---
+
+## Phase 5: User Story 3 — A gate that cannot judge (Priority: P3)
+
+**Goal**: a context that resolves but would report green without judging cannot be added to the required
+list.
+
+**Independent Test**: add `advisory / prek-advisory` to the committed required list and watch the suite
+fail quoting that capability's own recorded skip reason.
+
+### Implementation for User Story 3
+
+- [ ] T024 [US3] In `tests/capabilities.py`, add `cannot_judge` to the composed context, set by whichever
+      of the three conditions in [data-model.md](./data-model.md#composed-context) holds, carrying the
+      reason as text: the called capability's own `skips_under` reason from `published_surface.toml`, the
+      calling job's `if:` verbatim, or the events the calling workflow does declare.
+- [ ] T025 [US3] Pre-flight it against the tree by name: `advisory / prek-advisory` and
+      `describe / pr-description` must come back with a reason, both `release-on-merge` contexts and
+      `propose` must come back with the no-`pull_request` reason, and `ci / python-ci` must come back with
+      none.
+- [ ] T026 [US3] [FR-009](./spec.md#functional-requirements): no required context may carry
+      `cannot_judge`. One test, three reasons, and the failure quotes whichever reason applied — principle
+      VII made structural rather than written down.
+- [ ] T027 [US3] Prove it can fail, three ways: add `advisory / prek-advisory` to the committed required
+      list (a recorded skip), then `release-on-merge / tag-and-publish` (no `pull_request` trigger), then
+      `apply-ruleset / apply` (same). Each must fail with its own reason. Restore the file after each.
+
+**Checkpoint**: both halves of the gate hold. Every requirement in the spec is asserted by something that
+can fail.
+
+---
+
+## Phase 6: Polish & documentation
+
+**Purpose**: the tree now says something the documentation contradicts. Stale framing is a defect, not a
+follow-up.
+
+- [ ] T028 `docs/ai-instructions.md`, the CI section at line 165. Its claim that **"nothing in the tree can
+      see it"** is now false, and the instruction it justifies has become a gate. Rewrite it to name
+      `.github/rulesets/` as the owner and the gate as what holds it. Drop the "Two names are never
+      required" list in the same edit: the gate owns that fact now, and a prose copy of it is the second
+      owner principle I forbids.
+- [ ] T029 [P] `AGENTS.md`, the layer 3 table. Add a row for `.github/rulesets/` — "what the default
+      branch requires, and what a consumer's ruleset would require of it". Nothing else in that table
+      answers it.
+- [ ] T030 [P] Check `README.md` and expect no change: it describes what a consumer resolves, and neither
+      the applier nor the action is published ([FR-014](./spec.md#functional-requirements)). Its existing
+      statements about retiring a context are consumer-facing and stay true. Say so in the pull request
+      rather than editing to prove the check happened.
+- [ ] T031 Check `docs/technical-debt.md` and expect no row. R2's departure from the schema convention is
+      a settled decision with its reason recorded beside what enforces it (T006), not a shortcut nobody
+      will fix — and the doc's own admission bar requires all three of its conditions.
+- [ ] T032 `mise run ci` with the network unavailable, confirming
+      [SC-003](./spec.md#measurable-outcomes). Not "it passed on a machine with wifi".
+- [ ] T033 Walk [quickstart.md](./quickstart.md) end to end and correct anything it gets wrong about the
+      code as built — including the `composed_contexts()` snippet, which was written before the composer
+      was.
+
+---
+
+## Dependencies & execution order
+
+### Phase dependencies
+
+- **Phase 1** — no dependencies.
+- **Phase 2** — needs Phase 1. **Blocks every story**: both gates read the committed file, and a malformed
+  one makes both pass on an empty set.
+- **Phases 3, 4, 5** — each needs Phase 2 and none needs another. US1 writes to GitHub; US2 and US3 only
+  read the tree.
+- **Phase 6** — needs whichever stories landed.
+
+### Recommended order, which is not the priority order
+
+Land **Phase 4 and Phase 5 before Phase 3**, and in particular before T017.
+
+US1 is P1 because the committed file has to be the fact before a gate reading it means anything — and
+Phase 1 already delivers that half. What is left in Phase 3 is the applier, and applying is the one act
+here that no revert undoes: a wrong ruleset blocks every pull request in the repository, including the one
+that would fix it. The gate is what makes the committed file worth applying, so it goes first.
+
+Nothing enforces this. It is the order to choose absent a reason not to.
+
+### Within each story
+
+- The pre-flight comes with the reader it checks, never after — T007 with T004, T019 with T018, T025 with
+  T024. A reader committed without one is a gate nobody has seen fail.
+- The proof-of-failure task closes each story: T023, T027. Reverting the scratch edit is part of the task.
+
+### Parallel opportunities
+
+- T003 alongside T001 and T002 — different file.
+- T010, T011 alongside T008 and T009 — the action's YAML and the path wiring do not wait on the module.
+- T029, T030, T031 with each other — three different files, three independent checks.
+- Phases 4 and 5 in parallel with Phase 3, if two people are on it. They touch `capabilities.py` and
+  `test_ruleset_contexts.py`; Phase 3 touches neither except `published_surface.toml`, which Phase 4 reads
+  and does not write.
+
+Phases 4 and 5 both edit `capabilities.py` and `test_ruleset_contexts.py`, so they are sequential with
+each other.
+
+---
+
+## Implementation strategy
+
+### The smallest thing worth landing
+
+Phases 1, 2 and 4. That is the committed ruleset, its shape assertions, and the gate that fails on a
+retired context — which is the whole of issue #6's complaint. The applier can follow; until it does, the
+ruleset is applied by hand as it is today, and the committed file is a second copy for exactly as long as
+that lasts. Do not stop there deliberately: [R1](./research.md#r1--what-the-committed-file-holds)'s second
+copy is what principle I forbids, and this is a staging order rather than a shipping one.
+
+### Incremental delivery
+
+1. Phases 1 + 2 → the ruleset is in the tree and cannot be malformed.
+2. Phase 4 → a retired context fails the pull request. **This is the issue closed.**
+3. Phase 5 → a context that cannot judge cannot be required.
+4. Phase 3 → the tree becomes the applied source, and the hand edit goes away.
+5. Phase 6 → the documentation stops contradicting the tree.
+
+### What this feature must not change
+
+The enforced ruleset. Same three required contexts before and after
+([FR-013](./spec.md#functional-requirements), SC-006). If the first real dispatch reports a change, stop
+and read it — a wrong apply cannot be reverted, and being a no-op is the only reason this feature is safe
+to land in one pull request.
+
+---
+
+## Notes
+
+- One green commit per task or per logical group, Conventional Commits subject.
+- `mise run ci` before each commit. Auto-fixing hooks are normal — re-stage and retry.
+- Two tasks deliberately produce no diff: T030 and T031 are checks whose result is reported in the pull
+  request. A check that quietly edits something to look productive is worse than the check.
+- This feature's own required contexts do not change, so this repository's branch ruleset needs no edit to
+  merge this work — the one time that is true of a change to what reports.

--- a/specs/002-ruleset-in-tree/tasks.md
+++ b/specs/002-ruleset-in-tree/tasks.md
@@ -181,28 +181,28 @@ that does it, naming what would stop reporting.
 
 ### Implementation for User Story 2
 
-- [ ] T018 [US2] In `tests/capabilities.py`, add the composer from
+- [X] T018 [US2] In `tests/capabilities.py`, add the composer from
       [R6](./research.md#r6--the-gates-two-halves): for every workflow under `.github/workflows`, for every
       job, the calling half is the job's `name` falling back to its id; where `uses:` names a capability in
       this repository, one context per `check_name` that capability records in `published_surface.toml`,
       spelled `<calling half> / <called job>`. A job calling nothing composes its own name alone. Return a
       `NamedTuple` carrying the fields in
       [data-model.md](./data-model.md#composed-context) so a failure can name provenance.
-- [ ] T019 [US2] Pre-flight the composer against the tree by name: it must produce `ci / python-ci` from
+- [X] T019 [US2] Pre-flight the composer against the tree by name: it must produce `ci / python-ci` from
       `ci.yml`, both `commits / pr-title` and `commits / commit-messages` from `commit-messages.yml`, and
       `propose` from `release-proposal.yml`. This is the gate on the gate — a composer that stops reading
       `uses:` would otherwise report green over every retired name at once.
-- [ ] T020 [US2] In `tests/test_ruleset_contexts.py`, [FR-008](./spec.md#functional-requirements): every
+- [X] T020 [US2] In `tests/test_ruleset_contexts.py`, [FR-008](./spec.md#functional-requirements): every
       required context in every committed ruleset is composed by the tree. Both halves — a context naming a
       called job that `published_surface.toml` does not record fails too.
-- [ ] T021 [US2] [FR-010](./spec.md#functional-requirements): the failure names the context, where it is
+- [X] T021 [US2] [FR-010](./spec.md#functional-requirements): the failure names the context, where it is
       required, what composes it or fails to, and that the committed ruleset must be edited in the same
       change. Assert the message content, not only the failure — a gate whose message says nothing is an
       exit code, and the conventions layer says that is not a result.
-- [ ] T022 [US2] Assert the deliberate non-failure: a context the tree composes but the ruleset does not
+- [X] T022 [US2] Assert the deliberate non-failure: a context the tree composes but the ruleset does not
       require passes. Requiring more is a maintainer's decision and not this gate's
       ([spec.md Story 2, scenario 4](./spec.md#user-story-2---a-retired-context-fails-the-pull-request-priority-p2)).
-- [ ] T023 [US2] Prove it can fail. Rename `ci.yml`'s job `ci` to `gates`, run
+- [X] T023 [US2] Prove it can fail. Rename `ci.yml`'s job `ci` to `gates`, run
       `uv run pytest tests/test_ruleset_contexts.py`, read the message, restore the file. This is the exact
       change that went unnoticed for six commits in `001-consumer-contract`; if the suite passes, the gate
       is reading the wrong thing.

--- a/specs/002-ruleset-in-tree/tasks.md
+++ b/specs/002-ruleset-in-tree/tasks.md
@@ -251,26 +251,33 @@ can fail.
 **Purpose**: the tree now says something the documentation contradicts. Stale framing is a defect, not a
 follow-up.
 
-- [ ] T028 `docs/ai-instructions.md`, the CI section at line 165. Its claim that **"nothing in the tree can
-      see it"** is now false, and the instruction it justifies has become a gate. Rewrite it to name
-      `.github/rulesets/` as the owner and the gate as what holds it. Drop the "Two names are never
-      required" list in the same edit: the gate owns that fact now, and a prose copy of it is the second
-      owner principle I forbids.
-- [ ] T029 [P] `AGENTS.md`, the layer 3 table. Add a row for `.github/rulesets/` — "what the default
+- [X] T028 `docs/ai-instructions.md`, the CI section's claim that **"nothing in the tree can see it"**
+      (not "line 165" as originally written here — that line number named the section's opening
+      sentence, not the false claim, which sits two lines below it; a citation that drifts with the
+      first edit it prompts is the wrong kind of precision, so the fix is quoted by text instead). The
+      claim is now false, and the instruction it justifies has become a gate. Rewritten to name
+      `.github/rulesets/` as the owner and `tests/test_ruleset_contexts.py` as the gate that holds it.
+      Dropped the "Two names are never required" list in the same edit: `published_surface.toml`'s
+      `judges` field and the gate own that fact now, and a prose copy of it is the second owner
+      principle I forbids.
+- [X] T029 [P] `AGENTS.md`, the layer 3 table. Add a row for `.github/rulesets/` — "what the default
       branch requires, and what a consumer's ruleset would require of it". Nothing else in that table
       answers it.
-- [ ] T030 [P] Check `README.md` and expect no change: it describes what a consumer resolves, and neither
+- [X] T030 [P] Check `README.md` and expect no change: it describes what a consumer resolves, and neither
       the applier nor the action is published ([FR-014](./spec.md#functional-requirements)). Its existing
       statements about retiring a context are consumer-facing and stay true. Say so in the pull request
       rather than editing to prove the check happened.
-- [ ] T031 Check `docs/technical-debt.md` and expect no row. R2's departure from the schema convention is
+- [X] T031 Check `docs/technical-debt.md` and expect no row. R2's departure from the schema convention is
       a settled decision with its reason recorded beside what enforces it (T006), not a shortcut nobody
       will fix — and the doc's own admission bar requires all three of its conditions.
-- [ ] T032 `mise run ci` with the network unavailable, confirming
+- [X] T032 `mise run ci` with the network unavailable, confirming
       [SC-003](./spec.md#measurable-outcomes). Not "it passed on a machine with wifi".
-- [ ] T033 Walk [quickstart.md](./quickstart.md) end to end and correct anything it gets wrong about the
-      code as built — including the `composed_contexts()` snippet, which was written before the composer
-      was.
+- [X] T033 Walk [quickstart.md](./quickstart.md) end to end and correct anything it gets wrong about the
+      code as built. The `composed_contexts()` snippet already matched the built composer; what had gone
+      stale was the count (eight contexts → nine, once `apply-ruleset.yml` joined the tree), the
+      `prek-advisory` proof's expected reason (it quoted a `skips_under` sentence; the actual reason now
+      comes from `judges = false`, per the Phase 5 fix), and both `gh workflow run apply-ruleset.yml`
+      examples, which omitted the now-required `ruleset` input.
 
 ---
 

--- a/specs/002-ruleset-in-tree/tasks.md
+++ b/specs/002-ruleset-in-tree/tasks.md
@@ -115,41 +115,41 @@ nothing written; dispatch again with the dry run off and read the change back fr
 
 ### Implementation for User Story 1
 
-- [ ] T008 [US1] `actions/ruleset-decisions/rulesets.py` — the decision unit from
+- [X] T008 [US1] `actions/ruleset-decisions/rulesets.py` — the decision unit from
       [contracts/ruleset-decisions.md](./contracts/ruleset-decisions.md). Standard library only, every
       argument from the environment (`COMMITTED`, `LIVE`, `BODY_PATH`), nothing written outside
       `BODY_PATH`. Normalise per [R4](./research.md#r4--comparison-by-meaning); select the live match per
       [R5](./research.md#r5--finding-the-ruleset); emit `verdict`, `ruleset-id`, `difference`, `body`,
       `message` to `GITHUB_OUTPUT`. Mirror `actions/release-decisions/decisions.py` for shape.
-- [ ] T009 [US1] Every failure message names what was read, what it was compared against, and what to do
+- [X] T009 [US1] Every failure message names what was read, what it was compared against, and what to do
       about it — the four rows in
       [the contract's failure table](./contracts/ruleset-decisions.md#failure-messages). A malformed
       committed file is a `refuse` verdict, not a traceback.
-- [ ] T010 [P] [US1] `actions/ruleset-decisions/action.yml` — composite, inputs `committed`, `live`,
+- [X] T010 [P] [US1] `actions/ruleset-decisions/action.yml` — composite, inputs `committed`, `live`,
       `body-path`; outputs as above; one step passing every value through `env:` and running
       `python3 "$GITHUB_ACTION_PATH/rulesets.py"`. Copy the env-only discipline from
       `actions/release-decisions/action.yml` — principle VI, and `test_no_interpolation.py` reads this
       file.
-- [ ] T011 [P] [US1] `tests/conftest.py` — insert `actions/ruleset-decisions` on `sys.path` beside the
+- [X] T011 [P] [US1] `tests/conftest.py` — insert `actions/ruleset-decisions` on `sys.path` beside the
       existing entry, with the same reason it already carries: a hyphen in the directory name means it is
       not importable as a package.
-- [ ] T012 [US1] `pyproject.toml` — add `actions/ruleset-decisions` to `[tool.pyright].extraPaths`, and
+- [X] T012 [US1] `pyproject.toml` — add `actions/ruleset-decisions` to `[tool.pyright].extraPaths`, and
       add `actions/ruleset-decisions` to `[tool.turbobasic-release].exclude` per
       [R7](./research.md#r7--release-relevance). The open question there is settled: `matches()` in
       `decisions.py` tries `fnmatch(path, f"{pattern}/*")`, so the bare directory covers both files and no
       glob is needed. Keep the exclude list sorted as it is.
-- [ ] T013 [US1] `tests/published_surface.toml` — a row for `ruleset-decisions`: `kind = "action"`,
+- [X] T013 [US1] `tests/published_surface.toml` — a row for `ruleset-decisions`: `kind = "action"`,
       `published = false`, empty `inputs`, `permissions`, `tool_prerequisites` and `skips_under`, mirroring
       `release-decisions`. Without it `test_every_capability_in_the_tree_is_in_the_fixture` fails, which is
       the gate working.
-- [ ] T014 [US1] `tests/test_ruleset_decisions.py` — the four verdicts from
+- [X] T014 [US1] `tests/test_ruleset_decisions.py` — the four verdicts from
       [data-model.md](./data-model.md#apply-verdict): `create` when no live ruleset carries the name,
       `nothing` when the projection matches, `update` with a populated `difference` when it does not,
       `refuse` when two rulesets share the name ([FR-007](./spec.md#functional-requirements)). Plus: a live
       ruleset carrying `updated_at` and `_links` still reads as `nothing`, and reordered `rules` and
       `required_status_checks` still read as `nothing` — R4's whole point. Offline; the live side is a
       fixture built in the test.
-- [ ] T015 [US1] `.github/workflows/apply-ruleset.yml` — `workflow_dispatch` only
+- [X] T015 [US1] `.github/workflows/apply-ruleset.yml` — `workflow_dispatch` only
       ([FR-003](./spec.md#functional-requirements)), inputs `ruleset` and `dry-run` with `dry-run`
       defaulting to `true` (FR-004, [R9](./research.md#r9--why-there-is-no-drift-refusal)); one job with
       `timeout-minutes`; `contents: read` on the run's token for the checkout; an App token from
@@ -159,9 +159,10 @@ nothing written; dispatch again with the dry run off and read the change back fr
       `uses: $/actions/ruleset-decisions`, prints the difference unconditionally (FR-005), and writes with
       `gh api --input "$body"` only when the verdict is `create` or `update` **and** the dry run is off.
       Never a body as an argument. Every permission line carries its reason.
-- [ ] T016 [US1] Add `.github/workflows/apply-ruleset.yml` to `[tool.turbobasic-release].exclude` in
+- [X] T016 [US1] Add `.github/workflows/apply-ruleset.yml` to `[tool.turbobasic-release].exclude` in
       `pyproject.toml` — same reason as T012, and the same reason every other caller workflow of this
-      repository is already listed there.
+      repository is already listed there. (Already present from the proactive T012 edit; confirmed still
+      correct once the workflow file existed.)
 - [ ] T017 [US1] Verify by dispatch, in dry run, after the branch has merged:
       `gh workflow run apply-ruleset.yml`. Expect **nothing to change**
       ([R10](./research.md#r10--what-the-first-apply-must-not-change)). A difference means T001 was
@@ -237,7 +238,8 @@ fail quoting that capability's own recorded skip reason.
       VII made structural rather than written down.
 - [X] T027 [US3] Prove it can fail, three ways: add `advisory / prek-advisory` to the committed required
       list (`judges = false`), then `release / tag-and-publish` (no `pull_request` trigger), then
-      `apply-ruleset / apply` (same). Each must fail with its own reason. Restore the file after each.
+      `apply` (same — the applier's job calls no reusable workflow, so its composed context is its own
+      job name with no prefix). Each must fail with its own reason. Restore the file after each.
 
 **Checkpoint**: both halves of the gate hold. Every requirement in the spec is asserted by something that
 can fail.

--- a/specs/002-ruleset-in-tree/tasks.md
+++ b/specs/002-ruleset-in-tree/tasks.md
@@ -83,21 +83,21 @@ to prevent, reappearing inside it.
 
 **⚠️ No user story work begins until this phase is complete.**
 
-- [ ] T004 In `tests/capabilities.py` — already the one owner of how a workflow is read — add
+- [X] T004 In `tests/capabilities.py` — already the one owner of how a workflow is read — add
       `RULESET_DIR = REPO / ".github" / "rulesets"`, `ruleset_docs() -> dict[str, Doc]` keyed by file stem,
       `WRITABLE_FIELDS`, and `required_contexts(doc) -> list[str]` reading
       `rules[type == required_status_checks].parameters.required_status_checks[].context`. Full type hints;
       `json.loads`, not a new dependency.
-- [ ] T005 In `tests/test_ruleset_contexts.py` (new), the [FR-012](./spec.md#functional-requirements)
+- [X] T005 In `tests/test_ruleset_contexts.py` (new), the [FR-012](./spec.md#functional-requirements)
       assertions from [data-model.md](./data-model.md#validation-fr-012): the key set is exactly
       `WRITABLE_FIELDS`; exactly one rule is `required_status_checks`; its context list is non-empty and
       every entry has a non-empty `context`; `target` is `branch`.
-- [ ] T006 In the same file, record beside those assertions why there is no `check-jsonschema` hook —
+- [X] T006 In the same file, record beside those assertions why there is no `check-jsonschema` hook —
       [R2](./research.md#r2--no-schema-hook) in two or three lines, stating the rule and not the history:
       the tool ships no ruleset schema, a remote one would put the network in `mise run ci`, and unlike
       `.github/actionlint.yaml` a mis-keyed field here fails *green* rather than safe. JSON carries no
       comments, so this is the only place the reason can live next to what enforces it.
-- [ ] T007 Pre-flight `required_contexts()` against a literal built in the test, per the conventions
+- [X] T007 Pre-flight `required_contexts()` against a literal built in the test, per the conventions
       layer: a reader that silently stops matching reports green over a file full of retired names. Assert
       it finds a context it is given, and returns `[]` for a ruleset with no such rule.
 

--- a/specs/002-ruleset-in-tree/tasks.md
+++ b/specs/002-ruleset-in-tree/tasks.md
@@ -221,19 +221,22 @@ fail quoting that capability's own recorded skip reason.
 
 ### Implementation for User Story 3
 
-- [ ] T024 [US3] In `tests/capabilities.py`, add `cannot_judge` to the composed context, set by whichever
+- [X] T024 [US3] In `tests/capabilities.py`, add `cannot_judge` to the composed context, set by whichever
       of the three conditions in [data-model.md](./data-model.md#composed-context) holds, carrying the
-      reason as text: the called capability's own `skips_under` reason from `published_surface.toml`, the
-      calling job's `if:` verbatim, or the events the calling workflow does declare.
-- [ ] T025 [US3] Pre-flight it against the tree by name: `advisory / prek-advisory` and
+      reason as text: a fixed sentence naming the capability when it is marked `judges = false` in
+      `published_surface.toml`, the calling job's `if:` verbatim, or the events the calling workflow does
+      declare. A capability's `skips_under` entry does not by itself disqualify a context — see
+      [data-model.md](./data-model.md#composed-context) for why `commits / pr-title` and
+      `commits / commit-messages` must stay unaffected by it.
+- [X] T025 [US3] Pre-flight it against the tree by name: `advisory / prek-advisory` and
       `describe / pr-description` must come back with a reason, both `release-on-merge` contexts and
       `propose` must come back with the no-`pull_request` reason, and `ci / python-ci` must come back with
       none.
-- [ ] T026 [US3] [FR-009](./spec.md#functional-requirements): no required context may carry
+- [X] T026 [US3] [FR-009](./spec.md#functional-requirements): no required context may carry
       `cannot_judge`. One test, three reasons, and the failure quotes whichever reason applied — principle
       VII made structural rather than written down.
-- [ ] T027 [US3] Prove it can fail, three ways: add `advisory / prek-advisory` to the committed required
-      list (a recorded skip), then `release-on-merge / tag-and-publish` (no `pull_request` trigger), then
+- [X] T027 [US3] Prove it can fail, three ways: add `advisory / prek-advisory` to the committed required
+      list (`judges = false`), then `release / tag-and-publish` (no `pull_request` trigger), then
       `apply-ruleset / apply` (same). Each must fail with its own reason. Restore the file after each.
 
 **Checkpoint**: both halves of the gate hold. Every requirement in the spec is asserted by something that

--- a/tests/capabilities.py
+++ b/tests/capabilities.py
@@ -2,7 +2,7 @@ import json
 import tomllib
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 import yaml
 
@@ -91,6 +91,76 @@ def check_names(doc: Doc) -> list[str]:
     # A consumer's required context is its own job id, then the called job's name. Where a job
     # declares no name GitHub falls back to its id, so that is what a consumer would have to require.
     return sorted(str(job.get("name", job_id)) for job_id, job in jobs(doc).items())
+
+
+class ComposedContext(NamedTuple):
+    context: str
+    workflow: str
+    job: str
+    calls: str | None
+    cannot_judge: str | None
+
+
+def _called_capability(uses: str) -> str | None:
+    # Only a job-level `uses:` reaching this repository's own workflows composes a context beyond
+    # its own name — the only place `$/.github/workflows/<name>.yml` can point.
+    prefix = "$/.github/workflows/"
+    if not uses.startswith(prefix):
+        return None
+    return uses.removeprefix(prefix).removesuffix(".yml")
+
+
+def _cannot_judge(
+    job: Doc, wf_triggers: Doc, capability: str | None, called_job: str | None
+) -> str | None:
+    if capability is not None and called_job is not None:
+        for entry in cast(list[Doc], fixture().get(capability, {}).get("skips_under", [])):
+            if called_job in cast(list[Any], entry.get("jobs", [])):
+                return str(entry["reason"])
+    if "if" in job:
+        return str(job["if"])
+    if "pull_request" not in wf_triggers:
+        events = ", ".join(str(event) for event in wf_triggers) or "no events"
+        return f"the workflow declares no pull_request trigger, only {events}"
+    return None
+
+
+def composed_contexts() -> list[ComposedContext]:
+    # Reads only caller workflows — a capability's own jobs are not what a ruleset can require.
+    out: list[ComposedContext] = []
+    for wf_name, doc in workflow_docs().items():
+        if is_capability(doc):
+            continue
+        wf_triggers = triggers(doc)
+        for job_id, job in jobs(doc).items():
+            if not isinstance(job, dict):
+                continue
+            job = cast(Doc, job)
+            calling_half = str(job.get("name", job_id))
+            capability = _called_capability(str(job["uses"])) if "uses" in job else None
+            called_names = fixture().get(capability, {}).get("check_name") if capability else None
+            if called_names:
+                for called_job in cast(list[str], called_names):
+                    out.append(
+                        ComposedContext(
+                            context=f"{calling_half} / {called_job}",
+                            workflow=wf_name,
+                            job=job_id,
+                            calls=capability,
+                            cannot_judge=_cannot_judge(job, wf_triggers, capability, called_job),
+                        )
+                    )
+            else:
+                out.append(
+                    ComposedContext(
+                        context=calling_half,
+                        workflow=wf_name,
+                        job=job_id,
+                        calls=capability,
+                        cannot_judge=_cannot_judge(job, wf_triggers, capability, None),
+                    )
+                )
+    return out
 
 
 def declared_inputs(doc: Doc) -> set[str]:

--- a/tests/capabilities.py
+++ b/tests/capabilities.py
@@ -1,3 +1,4 @@
+import json
 import tomllib
 from collections.abc import Iterator
 from pathlib import Path
@@ -8,7 +9,14 @@ import yaml
 REPO = Path(__file__).resolve().parent.parent
 WORKFLOW_DIR = REPO / ".github" / "workflows"
 ACTION_DIR = REPO / "actions"
+RULESET_DIR = REPO / ".github" / "rulesets"
 FIXTURE = Path(__file__).parent / "published_surface.toml"
+
+# The six fields a write to the rulesets API accepts. Anything else on a committed file is a
+# validation failure, not an ignored one — a misspelled field would otherwise read as an absent one.
+WRITABLE_FIELDS = frozenset(
+    {"name", "target", "enforcement", "conditions", "rules", "bypass_actors"}
+)
 
 Doc = dict[Any, Any]
 
@@ -30,6 +38,21 @@ def workflow_docs() -> dict[str, Doc]:
 
 def action_docs() -> dict[str, Doc]:
     return {path.parent.name: load(path) for path in sorted(ACTION_DIR.glob("*/action.yml"))}
+
+
+def ruleset_docs() -> dict[str, Doc]:
+    return {
+        path.stem: cast(Doc, json.loads(path.read_text(encoding="utf-8")))
+        for path in sorted(RULESET_DIR.glob("*.json"))
+    }
+
+
+def required_contexts(doc: Doc) -> list[str]:
+    for rule in cast(list[Doc], doc.get("rules", [])):
+        if rule.get("type") == "required_status_checks":
+            checks = cast(list[Doc], rule.get("parameters", {}).get("required_status_checks", []))
+            return [str(check["context"]) for check in checks]
+    return []
 
 
 def workflow_paths() -> list[Path]:

--- a/tests/capabilities.py
+++ b/tests/capabilities.py
@@ -110,13 +110,9 @@ def _called_capability(uses: str) -> str | None:
     return uses.removeprefix(prefix).removesuffix(".yml")
 
 
-def _cannot_judge(
-    job: Doc, wf_triggers: Doc, capability: str | None, called_job: str | None
-) -> str | None:
-    if capability is not None and called_job is not None:
-        for entry in cast(list[Doc], fixture().get(capability, {}).get("skips_under", [])):
-            if called_job in cast(list[Any], entry.get("jobs", [])):
-                return str(entry["reason"])
+def _cannot_judge(job: Doc, wf_triggers: Doc, capability: str | None) -> str | None:
+    if capability is not None and fixture().get(capability, {}).get("judges", True) is False:
+        return f"{capability} never judges what it names; the run may report success without checking anything"
     if "if" in job:
         return str(job["if"])
     if "pull_request" not in wf_triggers:
@@ -139,6 +135,7 @@ def composed_contexts() -> list[ComposedContext]:
             calling_half = str(job.get("name", job_id))
             capability = _called_capability(str(job["uses"])) if "uses" in job else None
             called_names = fixture().get(capability, {}).get("check_name") if capability else None
+            cannot_judge = _cannot_judge(job, wf_triggers, capability)
             if called_names:
                 for called_job in cast(list[str], called_names):
                     out.append(
@@ -147,7 +144,7 @@ def composed_contexts() -> list[ComposedContext]:
                             workflow=wf_name,
                             job=job_id,
                             calls=capability,
-                            cannot_judge=_cannot_judge(job, wf_triggers, capability, called_job),
+                            cannot_judge=cannot_judge,
                         )
                     )
             else:
@@ -157,7 +154,7 @@ def composed_contexts() -> list[ComposedContext]:
                         workflow=wf_name,
                         job=job_id,
                         calls=capability,
-                        cannot_judge=_cannot_judge(job, wf_triggers, capability, None),
+                        cannot_judge=cannot_judge,
                     )
                 )
     return out

--- a/tests/capabilities.py
+++ b/tests/capabilities.py
@@ -1,4 +1,5 @@
 import json
+import re
 import tomllib
 from collections.abc import Iterator
 from pathlib import Path
@@ -12,13 +13,11 @@ ACTION_DIR = REPO / "actions"
 RULESET_DIR = REPO / ".github" / "rulesets"
 FIXTURE = Path(__file__).parent / "published_surface.toml"
 
-# The six fields a write to the rulesets API accepts. Anything else on a committed file is a
-# validation failure, not an ignored one — a misspelled field would otherwise read as an absent one.
-WRITABLE_FIELDS = frozenset(
-    {"name", "target", "enforcement", "conditions", "rules", "bypass_actors"}
-)
-
 Doc = dict[Any, Any]
+
+# A called job's `if:` names the inputs that gate it. Reading them out of the condition is what lets a
+# caller's `with:` be judged against it, rather than trusting prose in the input's description.
+INPUT_REF = re.compile(r"inputs\.([A-Za-z0-9_-]+)")
 
 # A workflow's `on:` key is YAML 1.1's `true`, so a parser hands it back as the boolean and every
 # lookup by the string finds nothing. Both spellings are read, because which one arrives depends on
@@ -121,6 +120,29 @@ def _cannot_judge(job: Doc, wf_triggers: Doc, capability: str | None) -> str | N
     return None
 
 
+def switched_off(job: Doc, capability: str | None, called_job: str) -> str | None:
+    # The caller's own `with:` read against the called job's `if:`. A capability whose input switches a
+    # check off skips that job, and a skipped job reports success — so the context it composes stops
+    # judging while still reporting green. Anything but the default or a literal `true` is refused: an
+    # expression cannot be resolved offline, so it is not provably on either.
+    if capability is None:
+        return None
+    doc = workflow_docs().get(capability)
+    if doc is None:
+        return None
+    given = cast(Doc, job.get("with") or {})
+    for job_id, called in jobs(doc).items():
+        if not isinstance(called, dict) or str(cast(Doc, called).get("name", job_id)) != called_job:
+            continue
+        for name in INPUT_REF.findall(str(cast(Doc, called).get("if", ""))):
+            if name in given and given[name] is not True:
+                return (
+                    f"the call passes {name}: {given[name]!r}, and {capability}'s {called_job} job is "
+                    f"gated on inputs.{name} — a skipped job reports success"
+                )
+    return None
+
+
 def composed_contexts() -> list[ComposedContext]:
     # Reads only caller workflows — a capability's own jobs are not what a ruleset can require.
     out: list[ComposedContext] = []
@@ -144,7 +166,7 @@ def composed_contexts() -> list[ComposedContext]:
                             workflow=wf_name,
                             job=job_id,
                             calls=capability,
-                            cannot_judge=cannot_judge,
+                            cannot_judge=cannot_judge or switched_off(job, capability, called_job),
                         )
                     )
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
-# The decision unit lives beside the action that runs it, and a hyphen in that directory name means it
-# is not importable as a package. pyright reaches it through `extraPaths` in pyproject.toml.
-sys.path.insert(0, str(Path(__file__).parent.parent / "actions" / "release-decisions"))
+# Each decision unit lives beside the action that runs it, and a hyphen in that directory name means
+# neither is importable as a package. pyright reaches both through `extraPaths` in pyproject.toml.
+ACTIONS = Path(__file__).parent.parent / "actions"
+sys.path.insert(0, str(ACTIONS / "release-decisions"))
+sys.path.insert(0, str(ACTIONS / "ruleset-decisions"))

--- a/tests/published_surface.toml
+++ b/tests/published_surface.toml
@@ -124,6 +124,16 @@ jobs = ["prek-advisory"]
 event = "any event but pull_request"
 reason = "there is no pull request to comment on. This capability is advertised as advisory rather than as a required gate, which is why principle VII exempts it by name — a consumer that requires this context has misread what it is for"
 
+[ruleset-decisions]
+kind = "action"
+# Internal surface, for the same reason release-decisions is: no stability promise, no check name, and
+# inputs nothing outside this repository names.
+published = false
+inputs = []
+permissions = {}
+tool_prerequisites = []
+skips_under = []
+
 [release-decisions]
 kind = "action"
 # Internal surface: no stability promise, no check name, and inputs nothing outside this repository

--- a/tests/published_surface.toml
+++ b/tests/published_surface.toml
@@ -23,9 +23,13 @@
 #   tool_prerequisites  tools the capability invokes that the consumer's own configuration must pin.
 #                       Empty when the capability provisions its own.
 #   skips_under         every event-conditional job-level `if:`, as `{ jobs, event, reason }`. One
-#                       entry may cover several jobs that skip for the same reason; `jobs` is what
-#                       makes the gate per-job, since a skipped job reports success and an unreasoned
-#                       skip is a required check that passes without reading anything.
+#                       entry may cover several jobs that skip for the same reason. Documentation of
+#                       the condition, not itself a reason to refuse a required context: a caller that
+#                       only ever fires under the one event the job does not skip is unaffected by it.
+#   judges              false marks a capability whose job goes green without judging what it names —
+#                       advisory (reports success regardless of findings) or write-only (nothing to
+#                       pass or fail). Absent means true. This is what a required context is refused
+#                       for; `skips_under` alone is not enough to tell the two apart.
 #
 # Each row arrives in the same change as the capability it describes.
 
@@ -71,6 +75,8 @@ reason = "there is no title and no range to judge; a consumer must not require t
 kind = "workflow"
 published = true
 check_name = ["pr-description"]
+# It renders a body; there is no criterion by which that render passes or fails.
+judges = false
 # Two inputs and nothing else. No token, no pull request number, no repository, no SHA range: the
 # capability owns its own checkout and reads all of it from the run, which is what removes the
 # shallow-checkout failure mode rather than documenting it.
@@ -99,6 +105,8 @@ skips_under = []
 kind = "workflow"
 published = true
 check_name = ["prek-advisory"]
+# Its own lint step swallows a non-zero exit; the job reports success whether or not it found anything.
+judges = false
 # No cache-prek: caching is unconditional. No mise-version: six call sites could have set it and none
 # did, and removing an input is a break where never adding one is not.
 inputs = ["hook-stage", "timeout-minutes"]

--- a/tests/test_published_surface.py
+++ b/tests/test_published_surface.py
@@ -18,7 +18,7 @@ from capabilities import (
 REQUIRED = frozenset(
     {"kind", "published", "inputs", "permissions", "tool_prerequisites", "skips_under"}
 )
-OPTIONAL = frozenset({"check_name"})
+OPTIONAL = frozenset({"check_name", "judges"})
 
 
 def tree_surface() -> dict[str, Doc]:

--- a/tests/test_ruleset_contexts.py
+++ b/tests/test_ruleset_contexts.py
@@ -1,4 +1,4 @@
-from capabilities import WRITABLE_FIELDS, Doc, required_contexts, ruleset_docs
+from capabilities import WRITABLE_FIELDS, Doc, composed_contexts, required_contexts, ruleset_docs
 
 # No check-jsonschema hook covers this file: the tool ships no schema for a repository ruleset, and
 # a `--schemafile <url>` would put the network in `mise run ci`. A mis-keyed required-status-checks
@@ -58,3 +58,49 @@ def test_required_contexts_finds_a_context_it_is_given() -> None:
 
 def test_required_contexts_returns_nothing_for_a_ruleset_with_no_such_rule() -> None:
     assert required_contexts({"rules": [{"type": "deletion"}]}) == []
+
+
+def test_composed_contexts_finds_the_contexts_the_tree_actually_reports() -> None:
+    # Pre-flight the composer against the tree by name, per the conventions layer: a composer that
+    # stops reading `uses:` would otherwise report green over every retired name at once. These four
+    # are confirmed against this repository's own reported check-run names, not guessed.
+    contexts = {c.context for c in composed_contexts()}
+    assert "ci / python-ci" in contexts
+    assert "commits / pr-title" in contexts
+    assert "commits / commit-messages" in contexts
+    assert "propose" in contexts
+
+
+def _unresolved(ruleset_name: str, context: str) -> str:
+    # FR-010: names the context, where it is required, and what to do about it. A rename or a
+    # retirement is the same fix either way — edit the committed ruleset in the same change.
+    return (
+        f"{ruleset_name} requires {context!r}, which nothing in the tree composes. A calling job "
+        "was renamed or retired, or the called job's name in published_surface.toml no longer "
+        f"matches. Edit .github/rulesets/{ruleset_name}.json in the same change"
+    )
+
+
+def test_every_required_context_is_composed_by_the_tree() -> None:
+    composed = {c.context for c in composed_contexts()}
+    for name, doc in ruleset_docs().items():
+        for context in required_contexts(doc):
+            assert context in composed, _unresolved(name, context)
+
+
+def test_the_unresolved_message_names_the_ruleset_the_context_and_what_to_do() -> None:
+    # FR-010, asserted on the message content rather than only the failure — an exit code alone is
+    # not a result.
+    message = _unresolved("protect-default-branch", "gates / python-ci")
+    assert "protect-default-branch" in message
+    assert "gates / python-ci" in message
+    assert ".github/rulesets/protect-default-branch.json" in message
+
+
+def test_a_context_the_tree_composes_but_does_not_require_causes_no_failure() -> None:
+    # Not every check is a gate. Requiring more is a maintainer's decision, not this gate's —
+    # spec.md Story 2, scenario 4. `advisory / prek-advisory` is composed and, deliberately, is not
+    # in the eight becoming three: its presence here asserts nothing failed above it.
+    composed = {c.context for c in composed_contexts()}
+    required = {context for doc in ruleset_docs().values() for context in required_contexts(doc)}
+    assert "advisory / prek-advisory" in composed - required

--- a/tests/test_ruleset_contexts.py
+++ b/tests/test_ruleset_contexts.py
@@ -1,45 +1,22 @@
-from capabilities import WRITABLE_FIELDS, Doc, composed_contexts, required_contexts, ruleset_docs
+from rulesets import shape_problem
+
+from capabilities import Doc, composed_contexts, required_contexts, ruleset_docs, switched_off
 
 # No check-jsonschema hook covers this file: the tool ships no schema for a repository ruleset, and
 # a `--schemafile <url>` would put the network in `mise run ci`. A mis-keyed required-status-checks
 # block would otherwise leave this gate reading zero required contexts and passing on an empty set —
 # a green gate that judged nothing — so the shape is asserted here instead, where that failure mode
 # is exactly what is being guarded against.
+#
+# `shape_problem` is the one owner of that shape, and the applier refuses on the same call. A second
+# implementation here would be two answers to what a write accepts; test_ruleset_decisions.py holds
+# what each refusal says.
 
 
-def test_a_committed_ruleset_holds_exactly_the_writable_fields() -> None:
+def test_every_committed_ruleset_is_a_shape_a_write_accepts() -> None:
     for name, doc in ruleset_docs().items():
-        unknown = set(doc) - WRITABLE_FIELDS
-        assert unknown == set(), (
-            f"{name}: unknown field {sorted(unknown)}, a write rejects anything but {sorted(WRITABLE_FIELDS)}"
-        )
-        missing = WRITABLE_FIELDS - set(doc)
-        assert missing == set(), f"{name}: missing field {sorted(missing)}"
-
-
-def test_a_committed_ruleset_targets_branches() -> None:
-    for name, doc in ruleset_docs().items():
-        assert doc["target"] == "branch", f"{name}: target {doc['target']!r}, expected 'branch'"
-
-
-def test_a_committed_ruleset_carries_exactly_one_required_status_checks_rule() -> None:
-    for name, doc in ruleset_docs().items():
-        types = [rule.get("type") for rule in doc["rules"]]
-        found = [t for t in types if t == "required_status_checks"]
-        assert len(found) == 1, (
-            f"{name}: rule types {types}, a ruleset requiring nothing gates nothing and the "
-            "context gate below would iterate an empty set"
-        )
-
-
-def test_a_committed_ruleset_requires_at_least_one_context() -> None:
-    for name, doc in ruleset_docs().items():
-        contexts = required_contexts(doc)
-        assert contexts != [], (
-            f"{name}: empty required-context list, the context gate would pass on an empty set"
-        )
-        for context in contexts:
-            assert context, f"{name}: a required-status-checks entry carries an empty context"
+        problem = shape_problem(doc)
+        assert problem is None, f".github/rulesets/{name}.json: {problem}"
 
 
 def test_required_contexts_finds_a_context_it_is_given() -> None:
@@ -122,6 +99,56 @@ def _cannot_be_required(ruleset_name: str, context: str, reason: str) -> str:
     )
 
 
+def test_a_call_that_switches_a_check_off_cannot_judge_the_context_it_composes() -> None:
+    # The half `skips_under` documents in prose and no gate held: `conventional-commits` says of its own
+    # `check-title` input that switching it off skips the job and a skipped job reports success. The
+    # composer reads the caller's `with:` against the called job's `if:`, so the prose is now a gate.
+    reason = switched_off(
+        {"uses": "$/.github/workflows/conventional-commits.yml", "with": {"check-title": False}},
+        "conventional-commits",
+        "pr-title",
+    )
+    assert reason is not None
+    assert "check-title" in reason
+    assert "pr-title" in reason
+
+
+def test_a_call_that_leaves_a_check_at_its_default_judges_normally() -> None:
+    for given in ({}, {"check-title": True}, {"timeout-minutes": 5}):
+        assert (
+            switched_off(
+                {"uses": "$/.github/workflows/conventional-commits.yml", "with": given},
+                "conventional-commits",
+                "pr-title",
+            )
+            is None
+        )
+
+
+def test_an_input_that_gates_no_job_switches_nothing_off() -> None:
+    # `types` appears in no job's `if:`, so passing it changes nothing about whether the job judges.
+    assert (
+        switched_off(
+            {"uses": "$/.github/workflows/conventional-commits.yml", "with": {"types": "feat"}},
+            "conventional-commits",
+            "pr-title",
+        )
+        is None
+    )
+
+
+def test_an_expression_valued_switch_is_refused_because_it_cannot_be_resolved_offline() -> None:
+    reason = switched_off(
+        {
+            "uses": "$/.github/workflows/conventional-commits.yml",
+            "with": {"check-commits": "${{ github.event_name == 'pull_request' }}"},
+        },
+        "conventional-commits",
+        "commit-messages",
+    )
+    assert reason is not None
+
+
 def test_no_required_context_can_skip_under_the_event_it_would_gate() -> None:
     cannot_judge = {c.context: c.cannot_judge for c in composed_contexts()}
     for name, doc in ruleset_docs().items():
@@ -142,7 +169,7 @@ def test_the_cannot_be_required_message_quotes_the_reason() -> None:
 def test_a_context_the_tree_composes_but_does_not_require_causes_no_failure() -> None:
     # Not every check is a gate. Requiring more is a maintainer's decision, not this gate's —
     # spec.md Story 2, scenario 4. `advisory / prek-advisory` is composed and, deliberately, is not
-    # in the eight becoming three: its presence here asserts nothing failed above it.
+    # in the required list: its presence here asserts nothing failed above it.
     composed = {c.context for c in composed_contexts()}
     required = {context for doc in ruleset_docs().values() for context in required_contexts(doc)}
     assert "advisory / prek-advisory" in composed - required

--- a/tests/test_ruleset_contexts.py
+++ b/tests/test_ruleset_contexts.py
@@ -1,0 +1,60 @@
+from capabilities import WRITABLE_FIELDS, Doc, required_contexts, ruleset_docs
+
+# No check-jsonschema hook covers this file: the tool ships no schema for a repository ruleset, and
+# a `--schemafile <url>` would put the network in `mise run ci`. A mis-keyed required-status-checks
+# block would otherwise leave this gate reading zero required contexts and passing on an empty set —
+# a green gate that judged nothing — so the shape is asserted here instead, where that failure mode
+# is exactly what is being guarded against.
+
+
+def test_a_committed_ruleset_holds_exactly_the_writable_fields() -> None:
+    for name, doc in ruleset_docs().items():
+        unknown = set(doc) - WRITABLE_FIELDS
+        assert unknown == set(), (
+            f"{name}: unknown field {sorted(unknown)}, a write rejects anything but {sorted(WRITABLE_FIELDS)}"
+        )
+        missing = WRITABLE_FIELDS - set(doc)
+        assert missing == set(), f"{name}: missing field {sorted(missing)}"
+
+
+def test_a_committed_ruleset_targets_branches() -> None:
+    for name, doc in ruleset_docs().items():
+        assert doc["target"] == "branch", f"{name}: target {doc['target']!r}, expected 'branch'"
+
+
+def test_a_committed_ruleset_carries_exactly_one_required_status_checks_rule() -> None:
+    for name, doc in ruleset_docs().items():
+        types = [rule.get("type") for rule in doc["rules"]]
+        found = [t for t in types if t == "required_status_checks"]
+        assert len(found) == 1, (
+            f"{name}: rule types {types}, a ruleset requiring nothing gates nothing and the "
+            "context gate below would iterate an empty set"
+        )
+
+
+def test_a_committed_ruleset_requires_at_least_one_context() -> None:
+    for name, doc in ruleset_docs().items():
+        contexts = required_contexts(doc)
+        assert contexts != [], (
+            f"{name}: empty required-context list, the context gate would pass on an empty set"
+        )
+        for context in contexts:
+            assert context, f"{name}: a required-status-checks entry carries an empty context"
+
+
+def test_required_contexts_finds_a_context_it_is_given() -> None:
+    # Pre-flight the reader, or a change that stops it matching reports green over a file full of
+    # retired names — the conventions layer's rule for a table reader, applied to this one.
+    given: Doc = {
+        "rules": [
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": [{"context": "ci / python-ci"}]},
+            }
+        ]
+    }
+    assert required_contexts(given) == ["ci / python-ci"]
+
+
+def test_required_contexts_returns_nothing_for_a_ruleset_with_no_such_rule() -> None:
+    assert required_contexts({"rules": [{"type": "deletion"}]}) == []

--- a/tests/test_ruleset_contexts.py
+++ b/tests/test_ruleset_contexts.py
@@ -97,6 +97,48 @@ def test_the_unresolved_message_names_the_ruleset_the_context_and_what_to_do() -
     assert ".github/rulesets/protect-default-branch.json" in message
 
 
+def test_cannot_judge_is_set_by_name_for_the_contexts_that_cannot_be_required() -> None:
+    # Pre-flight against the tree by name: each reason has a different cause, and a composer that
+    # stops reading any one of them would report green over exactly the context that reason exists
+    # to catch.
+    by_context = {c.context: c.cannot_judge for c in composed_contexts()}
+    assert by_context["advisory / prek-advisory"] is not None
+    assert by_context["describe / pr-description"] is not None
+    for context in ("verify / python-ci", "release / tag-and-publish", "propose"):
+        reason = by_context[context]
+        assert reason is not None
+        assert "pull_request" in reason
+    assert by_context["ci / python-ci"] is None
+
+
+def _cannot_be_required(ruleset_name: str, context: str, reason: str) -> str:
+    # FR-009, principle VII made structural: a required context that reports green without judging
+    # anything is a required gate nobody would ever see fail. The reason is quoted, not summarised,
+    # so the message is the record of why this one is exempt.
+    return (
+        f"{ruleset_name} requires {context!r}, which cannot judge anything: {reason}. "
+        f"Remove it from .github/rulesets/{ruleset_name}.json — a required gate never passes "
+        "without judging"
+    )
+
+
+def test_no_required_context_can_skip_under_the_event_it_would_gate() -> None:
+    cannot_judge = {c.context: c.cannot_judge for c in composed_contexts()}
+    for name, doc in ruleset_docs().items():
+        for context in required_contexts(doc):
+            reason = cannot_judge.get(context)
+            assert reason is None, _cannot_be_required(name, context, reason or "")
+
+
+def test_the_cannot_be_required_message_quotes_the_reason() -> None:
+    message = _cannot_be_required(
+        "protect-default-branch", "advisory / prek-advisory", "it is advisory"
+    )
+    assert "protect-default-branch" in message
+    assert "advisory / prek-advisory" in message
+    assert "it is advisory" in message
+
+
 def test_a_context_the_tree_composes_but_does_not_require_causes_no_failure() -> None:
     # Not every check is a gate. Requiring more is a maintainer's decision, not this gate's —
     # spec.md Story 2, scenario 4. `advisory / prek-advisory` is composed and, deliberately, is not

--- a/tests/test_ruleset_decisions.py
+++ b/tests/test_ruleset_decisions.py
@@ -1,0 +1,181 @@
+from typing import Any
+
+from rulesets import (
+    CREATE,
+    NOTHING,
+    REFUSE,
+    UPDATE,
+    Doc,
+    decide,
+    normalize,
+    render_difference,
+    shape_problem,
+)
+
+# A ruleset that admits every check below. Each test changes exactly what it is about.
+COMMITTED: Doc = {
+    "name": "protect-default-branch",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+    "rules": [
+        {"type": "deletion"},
+        {
+            "type": "required_status_checks",
+            "parameters": {"required_status_checks": [{"context": "ci / python-ci"}]},
+        },
+    ],
+    "bypass_actors": [{"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}],
+}
+
+LIVE_SUMMARY: Doc = {
+    "id": 1,
+    "name": "protect-default-branch",
+    "source_type": "Repository",
+    "target": "branch",
+    "enforcement": "active",
+}
+
+
+def _detail(**overrides: Any) -> Doc:
+    detail: Doc = {
+        **COMMITTED,
+        "id": 1,
+        "node_id": "n1",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "_links": {"self": {"href": "..."}},
+        "current_user_can_bypass": "always",
+    }
+    detail.update(overrides)
+    return detail
+
+
+def test_shape_problem_names_an_unknown_field() -> None:
+    bad: Doc = {**COMMITTED, "id": 1}
+    message = shape_problem(bad)
+    assert message is not None
+    assert "['id']" in message
+
+
+def test_shape_problem_names_a_missing_field() -> None:
+    bad = dict(COMMITTED)
+    del bad["bypass_actors"]
+    message = shape_problem(bad)
+    assert message is not None
+    assert "bypass_actors" in message
+
+
+def test_shape_problem_names_a_target_that_is_not_branch() -> None:
+    message = shape_problem({**COMMITTED, "target": "tag"})
+    assert message is not None
+    assert "'tag'" in message
+
+
+def test_shape_problem_names_the_absent_required_status_checks_rule() -> None:
+    bad = {**COMMITTED, "rules": [{"type": "deletion"}]}
+    message = shape_problem(bad)
+    assert message is not None
+    assert "['deletion']" in message
+
+
+def test_shape_problem_names_an_empty_context_list() -> None:
+    bad: Doc = {
+        **COMMITTED,
+        "rules": [{"type": "required_status_checks", "parameters": {"required_status_checks": []}}],
+    }
+    message = shape_problem(bad)
+    assert message is not None
+    assert "empty set" in message
+
+
+def test_shape_problem_is_none_for_a_well_formed_ruleset() -> None:
+    assert shape_problem(COMMITTED) is None
+
+
+def test_a_malformed_committed_file_refuses_before_any_live_ruleset_is_read() -> None:
+    bad = {**COMMITTED, "target": "tag"}
+    verdict = decide(bad, [], None)
+    assert verdict.verdict == REFUSE
+    assert "tag" in verdict.message
+
+
+def test_no_matching_name_creates() -> None:
+    verdict = decide(COMMITTED, [], None)
+    assert verdict.verdict == CREATE
+    assert verdict.body == COMMITTED
+
+
+def test_a_match_whose_source_type_is_not_repository_is_not_a_match() -> None:
+    organization_owned = {**LIVE_SUMMARY, "source_type": "Organization"}
+    verdict = decide(COMMITTED, [organization_owned], None)
+    assert verdict.verdict == CREATE
+
+
+def test_two_rulesets_sharing_the_name_refuse() -> None:
+    verdict = decide(COMMITTED, [LIVE_SUMMARY, {**LIVE_SUMMARY, "id": 2}], None)
+    assert verdict.verdict == REFUSE
+    assert "2 rulesets" in verdict.message
+    assert "'1'" in verdict.message
+    assert "'2'" in verdict.message
+
+
+def test_exactly_one_match_with_no_detail_refuses_rather_than_guesses() -> None:
+    verdict = decide(COMMITTED, [LIVE_SUMMARY], None)
+    assert verdict.verdict == REFUSE
+    assert "detail was not read" in verdict.message
+
+
+def test_a_matching_detail_reads_as_nothing_to_change() -> None:
+    verdict = decide(COMMITTED, [LIVE_SUMMARY], _detail())
+    assert verdict.verdict == NOTHING
+    assert verdict.ruleset_id == "1"
+    assert verdict.difference == ""
+    assert verdict.body is None
+
+
+def test_read_only_fields_do_not_cause_a_reported_difference() -> None:
+    # R4: id, node_id, created_at, updated_at, _links and current_user_can_bypass come back on a read
+    # and are not settable. A byte comparison would report drift on updated_at at every dispatch.
+    detail = _detail(updated_at="2099-01-01T00:00:00Z", current_user_can_bypass="never")
+    assert decide(COMMITTED, [LIVE_SUMMARY], detail).verdict == NOTHING
+
+
+def test_reordered_rules_and_contexts_still_read_as_nothing_to_change() -> None:
+    reordered = _detail(
+        rules=[
+            {
+                "type": "required_status_checks",
+                "parameters": {"required_status_checks": [{"context": "ci / python-ci"}]},
+            },
+            {"type": "deletion"},
+        ]
+    )
+    assert decide(COMMITTED, [LIVE_SUMMARY], reordered).verdict == NOTHING
+
+
+def test_a_real_difference_updates_with_the_difference_rendered_both_sides() -> None:
+    detail = _detail(enforcement="evaluate")
+    verdict = decide(COMMITTED, [LIVE_SUMMARY], detail)
+    assert verdict.verdict == UPDATE
+    assert verdict.ruleset_id == "1"
+    assert verdict.body == COMMITTED
+    assert "enforcement" in verdict.difference
+    assert "active" in verdict.difference
+    assert "evaluate" in verdict.difference
+
+
+def test_render_difference_names_both_sides_for_every_differing_field() -> None:
+    difference = render_difference(normalize(COMMITTED), normalize(_detail(target="tag")))
+    assert "target: committed='branch' live='tag'" in difference
+
+
+def test_normalize_drops_everything_but_the_six_writable_fields() -> None:
+    assert set(normalize(_detail())) == {
+        "name",
+        "target",
+        "enforcement",
+        "conditions",
+        "rules",
+        "bypass_actors",
+    }

--- a/tests/test_ruleset_decisions.py
+++ b/tests/test_ruleset_decisions.py
@@ -28,19 +28,14 @@ COMMITTED: Doc = {
     "bypass_actors": [{"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}],
 }
 
-LIVE_SUMMARY: Doc = {
-    "id": 1,
-    "name": "protect-default-branch",
-    "source_type": "Repository",
-    "target": "branch",
-    "enforcement": "active",
-}
-
 
 def _detail(**overrides: Any) -> Doc:
+    # What `GET /repos/{owner}/{repo}/rulesets/{id}` returns: the committed shape plus the read-only
+    # fields a write rejects. `decide` is handed a list of these, never the list endpoint's summaries.
     detail: Doc = {
         **COMMITTED,
         "id": 1,
+        "source_type": "Repository",
         "node_id": "n1",
         "created_at": "2026-01-01T00:00:00Z",
         "updated_at": "2026-01-01T00:00:00Z",
@@ -95,39 +90,37 @@ def test_shape_problem_is_none_for_a_well_formed_ruleset() -> None:
 
 def test_a_malformed_committed_file_refuses_before_any_live_ruleset_is_read() -> None:
     bad = {**COMMITTED, "target": "tag"}
-    verdict = decide(bad, [], None)
+    verdict = decide(bad, [])
     assert verdict.verdict == REFUSE
     assert "tag" in verdict.message
 
 
 def test_no_matching_name_creates() -> None:
-    verdict = decide(COMMITTED, [], None)
+    verdict = decide(COMMITTED, [])
     assert verdict.verdict == CREATE
     assert verdict.body == COMMITTED
 
 
 def test_a_match_whose_source_type_is_not_repository_is_not_a_match() -> None:
-    organization_owned = {**LIVE_SUMMARY, "source_type": "Organization"}
-    verdict = decide(COMMITTED, [organization_owned], None)
+    verdict = decide(COMMITTED, [_detail(source_type="Organization")])
+    assert verdict.verdict == CREATE
+
+
+def test_a_ruleset_of_another_name_is_not_a_match() -> None:
+    verdict = decide(COMMITTED, [_detail(name="something-else")])
     assert verdict.verdict == CREATE
 
 
 def test_two_rulesets_sharing_the_name_refuse() -> None:
-    verdict = decide(COMMITTED, [LIVE_SUMMARY, {**LIVE_SUMMARY, "id": 2}], None)
+    verdict = decide(COMMITTED, [_detail(), _detail(id=2)])
     assert verdict.verdict == REFUSE
     assert "2 rulesets" in verdict.message
     assert "'1'" in verdict.message
     assert "'2'" in verdict.message
 
 
-def test_exactly_one_match_with_no_detail_refuses_rather_than_guesses() -> None:
-    verdict = decide(COMMITTED, [LIVE_SUMMARY], None)
-    assert verdict.verdict == REFUSE
-    assert "detail was not read" in verdict.message
-
-
 def test_a_matching_detail_reads_as_nothing_to_change() -> None:
-    verdict = decide(COMMITTED, [LIVE_SUMMARY], _detail())
+    verdict = decide(COMMITTED, [_detail()])
     assert verdict.verdict == NOTHING
     assert verdict.ruleset_id == "1"
     assert verdict.difference == ""
@@ -138,7 +131,7 @@ def test_read_only_fields_do_not_cause_a_reported_difference() -> None:
     # R4: id, node_id, created_at, updated_at, _links and current_user_can_bypass come back on a read
     # and are not settable. A byte comparison would report drift on updated_at at every dispatch.
     detail = _detail(updated_at="2099-01-01T00:00:00Z", current_user_can_bypass="never")
-    assert decide(COMMITTED, [LIVE_SUMMARY], detail).verdict == NOTHING
+    assert decide(COMMITTED, [detail]).verdict == NOTHING
 
 
 def test_reordered_rules_and_contexts_still_read_as_nothing_to_change() -> None:
@@ -151,12 +144,11 @@ def test_reordered_rules_and_contexts_still_read_as_nothing_to_change() -> None:
             {"type": "deletion"},
         ]
     )
-    assert decide(COMMITTED, [LIVE_SUMMARY], reordered).verdict == NOTHING
+    assert decide(COMMITTED, [reordered]).verdict == NOTHING
 
 
 def test_a_real_difference_updates_with_the_difference_rendered_both_sides() -> None:
-    detail = _detail(enforcement="evaluate")
-    verdict = decide(COMMITTED, [LIVE_SUMMARY], detail)
+    verdict = decide(COMMITTED, [_detail(enforcement="evaluate")])
     assert verdict.verdict == UPDATE
     assert verdict.ruleset_id == "1"
     assert verdict.body == COMMITTED

--- a/tests/test_workflow_properties.py
+++ b/tests/test_workflow_properties.py
@@ -192,6 +192,74 @@ def test_no_step_in_the_release_path_writes_a_version() -> None:
     )
 
 
+# A ruleset write, read from the command rather than from a list this test also keeps. Only a write
+# sends a body, so `--input` is what separates the two calls in this workflow from the read above them.
+SENDS_A_BODY = "--input"
+
+
+def apply_steps() -> list[Doc]:
+    return steps_of("apply-ruleset", "apply")
+
+
+def test_the_applier_is_reachable_by_dispatch_and_a_schedule_alone() -> None:
+    # FR-003. A ruleset write has no revert, and a push or a merge trigger here would apply whatever
+    # the tree said at that commit before anyone had read the difference.
+    reached_by = set(triggers(load(WORKFLOW_DIR / "apply-ruleset.yml")))
+    assert reached_by == {"workflow_dispatch", "schedule"}, (
+        f"apply-ruleset is reachable from {sorted(reached_by)}. Applying is a human act, and the "
+        "schedule is the read that never writes"
+    )
+
+
+def test_every_ruleset_writing_step_is_gated_on_the_event_the_dry_run_and_the_verdict() -> None:
+    # The dispatch-only half of FR-003, which the trigger set above no longer holds on its own. Each
+    # of the three is a one-word deletion away from a cron that writes, a dry run that writes, or a
+    # write with nothing decided — and none of the three would look like anything in review.
+    found = 0
+    for step in apply_steps():
+        if SENDS_A_BODY not in str(step.get("run", "")):
+            continue
+        found += 1
+        condition = str(step.get("if", ""))
+        assert "github.event_name == 'workflow_dispatch'" in condition, (
+            f"apply-ruleset step {step.get('name')!r} writes under `if: {condition}`, which does not "
+            "pin the event. `inputs.dry-run` is absent on a schedule and an absent input compares "
+            "equal to false, so the cron would write"
+        )
+        assert "inputs.dry-run" in condition, (
+            f"apply-ruleset step {step.get('name')!r} writes under `if: {condition}`, which does not "
+            "exclude a dry run. A dry run that writes is not a dry run"
+        )
+        assert "steps.decide.outputs.verdict" in condition, (
+            f"apply-ruleset step {step.get('name')!r} writes under `if: {condition}`, which does not "
+            "read the verdict, so it would write over a refusal"
+        )
+    assert found == 1, (
+        f"{found} ruleset-writing steps found in apply-ruleset.yml, expected exactly one — this gate "
+        "is reading the wrong thing, or a second write appeared beside the gated one"
+    )
+
+
+def test_the_scheduled_read_fails_on_any_verdict_but_nothing() -> None:
+    # The drift alarm, and the one thing that makes the tree authoritative rather than aspirational.
+    # A condition that stops matching leaves a scheduled run reporting success over a live ruleset
+    # nobody is applying — green, having judged nothing.
+    alarm = [step for step in apply_steps() if step.get("id") == "drift"]
+    assert len(alarm) == 1, (
+        "apply-ruleset names no step `drift`, so nothing reports that the live ruleset stopped "
+        "matching the tree and every scheduled run is a green check that read nothing"
+    )
+    condition = str(alarm[0].get("if", ""))
+    assert "github.event_name == 'schedule'" in condition, (
+        f"the drift alarm runs under `if: {condition}`, which does not pin the schedule. A dispatch "
+        "exits successfully on a difference, because a difference is the reason to dispatch"
+    )
+    assert "verdict != 'nothing'" in condition, (
+        f"the drift alarm runs under `if: {condition}`, which does not read the verdict, so drift "
+        "either never fails or every run does"
+    )
+
+
 # An input naming which pull request, which repository, which commits, or with what token. The body
 # renderer reads every one of them from the run, which is what removed the shallow-checkout failure
 # mode instead of documenting it — so reintroducing any of these is a regression, not a feature.


### PR DESCRIPTION
## Summary

- Commits `protect-default-branch`'s live ruleset into `.github/rulesets/`, so what the default branch
  requires is edited in the tree rather than only in GitHub's settings UI.
- Adds `tests/capabilities.py`'s `composed_contexts()`/`cannot_judge` and `tests/test_ruleset_contexts.py`:
  a retired or renamed required context, or one that structurally cannot judge (advisory, write-only, or
  never fires on a pull request), fails the pull request that causes it rather than reporting green.
- Adds `actions/ruleset-decisions` (offline decision unit: create/update/nothing/refuse) and
  `.github/workflows/apply-ruleset.yml` (dispatch-only, dry by default) to apply the committed file.
- Updates `docs/ai-instructions.md`, `AGENTS.md`, and `quickstart.md` to match what the tree now enforces.

## Test plan

- [x] `mise run ci` green locally, including with network denied (`sandbox-exec -f ... deny network*`)
- [x] Proved the gate fails on: a renamed/retired composed context, an advisory/write-only context, a
  context whose workflow never fires on `pull_request` — each restored afterward
- [ ] After merge: dispatch `apply-ruleset.yml` in dry run and confirm it reports nothing to change
  (`gh workflow run apply-ruleset.yml -f ruleset=protect-default-branch`)