### PR TITLE
chore: close out the ruleset-in-tree feature

### DIFF
--- a/.github/workflows/apply-ruleset.yml
+++ b/.github/workflows/apply-ruleset.yml
@@ -1,13 +1,9 @@
 name: apply-ruleset
 
-# A ruleset is administrative surface with no revert once written, so a write only ever runs by hand. It
-# defaults to a dry run: the difference between the committed file and the live ruleset always prints
-# before anything is written, so a person reads it before choosing to proceed.
-#
-# The schedule writes nothing and cannot: the write step is reachable from `workflow_dispatch` alone
-# (FR-003). It exists because the tree is only authoritative if something notices when GitHub stops
-# matching it — a hand edit in the UI is otherwise invisible until the next dispatch, which may be
-# months away. So the scheduled run reads, and fails on any difference.
+# A ruleset write has no revert, so it runs by hand and dry by default: the difference always prints
+# before anything is written. The schedule only reads — the write step is reachable from
+# `workflow_dispatch` alone (FR-003) — and fails on any difference, because a hand edit in the UI is
+# otherwise invisible until someone next dispatches.
 on:
   workflow_dispatch:
     inputs:
@@ -84,11 +80,12 @@ jobs:
         with:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # The App behind these secrets must hold this, and its installation must have accepted it: a
+          # permission added to an App does not reach an installation until the account owner approves.
           permission-administration: write # the only right a ruleset read or write needs (R8)
 
-      # Every repository-owned ruleset in full, because the list endpoint's summary carries no rules,
-      # conditions or bypass_actors. `includes_parents=false` is what leaves out an organisation's,
-      # which this repository could not write even if it matched a committed name.
+      # In full, because a list-endpoint summary carries no rules, conditions or bypass_actors.
+      # `includes_parents=false` leaves out an organisation's, which this repository cannot write.
       - name: Read the live rulesets in full
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -134,8 +131,8 @@ jobs:
             gh api -X PUT "repos/$GH_REPO/rulesets/$RULESET_ID" --input "$BODY"
           fi
 
-      # The drift alarm. A dispatch exits successfully on a difference — that is the reason to dispatch
-      # — but a scheduled run finding one means GitHub stopped matching the tree with nobody watching.
+      # A dispatch exits successfully on a difference, since that is the reason to dispatch. A scheduled
+      # run finding one means GitHub stopped matching the tree with nobody watching.
       - id: drift
         name: Fail on drift
         if: github.event_name == 'schedule' && steps.decide.outputs.verdict != 'nothing'

--- a/actions/ruleset-decisions/rulesets.py
+++ b/actions/ruleset-decisions/rulesets.py
@@ -5,9 +5,8 @@ from typing import Any, NamedTuple, cast
 
 Doc = dict[str, Any]
 
-# The six fields a write to the rulesets API accepts. tests/capabilities.py owns the same fact for the
-# gate that reads the committed file from the tree; this module owns it for the workflow that writes it,
-# and neither imports the other — the action ships alone, and the suite runs with no network.
+# The six fields a write to the rulesets API accepts. Everything else a read returns is rejected on a
+# write, so the committed file holds these and comparison is over these alone.
 WRITABLE_FIELDS = frozenset(
     {"name", "target", "enforcement", "conditions", "rules", "bypass_actors"}
 )
@@ -108,9 +107,8 @@ def render_difference(committed: Doc, live: Doc) -> str:
 
 
 def decide(committed: Doc, live: list[Doc]) -> Verdict:
-    # `live` is every repository-owned ruleset as the detail endpoint returns it, not the list
-    # endpoint's summaries: the summary carries no rules, conditions or bypass_actors, so a caller
-    # handing those over would be comparing the committed file against fields that are simply absent.
+    # `live` holds details, not list-endpoint summaries: a summary carries no rules, conditions or
+    # bypass_actors, and comparing against absent fields reports drift that is not there.
     problem = shape_problem(committed)
     if problem:
         return Verdict(REFUSE, "", "", None, problem)

--- a/specs/002-ruleset-in-tree/tasks.md
+++ b/specs/002-ruleset-in-tree/tasks.md
@@ -163,10 +163,16 @@ nothing written; dispatch again with the dry run off and read the change back fr
       `pyproject.toml` — same reason as T012, and the same reason every other caller workflow of this
       repository is already listed there. (Already present from the proactive T012 edit; confirmed still
       correct once the workflow file existed.)
-- [ ] T017 [US1] Verify by dispatch, in dry run, after the branch has merged:
+- [X] T017 [US1] Verify by dispatch, in dry run, after the branch has merged:
       `gh workflow run apply-ruleset.yml`. Expect **nothing to change**
       ([R10](./research.md#r10--what-the-first-apply-must-not-change)). A difference means T001 was
       transcribed wrong — read it and do not proceed to a real dispatch.
+
+      Run `34533773004`: nothing to change, write skipped. The Assumption that the App already held
+      `administration: write` was wrong; it was granted and accepted first.
+
+      `create` and `update` were exercised afterwards, beyond this phase, against a `disabled` scratch
+      ruleset targeting no existing branch — each verified field-for-field, then deleted.
 
 **Checkpoint**: applying works and is a no-op. Nothing has been written to GitHub.
 

--- a/tests/capabilities.py
+++ b/tests/capabilities.py
@@ -15,8 +15,7 @@ FIXTURE = Path(__file__).parent / "published_surface.toml"
 
 Doc = dict[Any, Any]
 
-# A called job's `if:` names the inputs that gate it. Reading them out of the condition is what lets a
-# caller's `with:` be judged against it, rather than trusting prose in the input's description.
+# The inputs a job's `if:` consults, which are the ones a caller can switch it off with.
 INPUT_REF = re.compile(r"inputs\.([A-Za-z0-9_-]+)")
 
 # A workflow's `on:` key is YAML 1.1's `true`, so a parser hands it back as the boolean and every
@@ -121,10 +120,9 @@ def _cannot_judge(job: Doc, wf_triggers: Doc, capability: str | None) -> str | N
 
 
 def switched_off(job: Doc, capability: str | None, called_job: str) -> str | None:
-    # The caller's own `with:` read against the called job's `if:`. A capability whose input switches a
-    # check off skips that job, and a skipped job reports success — so the context it composes stops
-    # judging while still reporting green. Anything but the default or a literal `true` is refused: an
-    # expression cannot be resolved offline, so it is not provably on either.
+    # A switched-off check skips its job, and a skipped job reports success. Anything but the default or
+    # a literal `true` is refused, an expression included: it cannot be resolved offline, so it is not
+    # provably on.
     if capability is None:
         return None
     doc = workflow_docs().get(capability)

--- a/tests/test_ruleset_contexts.py
+++ b/tests/test_ruleset_contexts.py
@@ -2,15 +2,14 @@ from rulesets import shape_problem
 
 from capabilities import Doc, composed_contexts, required_contexts, ruleset_docs, switched_off
 
-# No check-jsonschema hook covers this file: the tool ships no schema for a repository ruleset, and
-# a `--schemafile <url>` would put the network in `mise run ci`. A mis-keyed required-status-checks
-# block would otherwise leave this gate reading zero required contexts and passing on an empty set —
-# a green gate that judged nothing — so the shape is asserted here instead, where that failure mode
-# is exactly what is being guarded against.
+# No check-jsonschema hook covers a committed ruleset: the tool ships no schema for one, and a
+# `--schemafile <url>` would put the network in `mise run ci`. The shape is asserted here instead,
+# because a mis-keyed required-status-checks block leaves the context gates below reading an empty set
+# and passing on it. `shape_problem` is the one owner of that shape; the applier refuses on the same
+# call, and test_ruleset_decisions.py holds what each refusal says.
 #
-# `shape_problem` is the one owner of that shape, and the applier refuses on the same call. A second
-# implementation here would be two answers to what a write accepts; test_ruleset_decisions.py holds
-# what each refusal says.
+# Every reader below is pre-flighted, by name against the tree or against a document it is given: a
+# reader that silently stops matching reports green over a file full of retired names.
 
 
 def test_every_committed_ruleset_is_a_shape_a_write_accepts() -> None:
@@ -20,8 +19,6 @@ def test_every_committed_ruleset_is_a_shape_a_write_accepts() -> None:
 
 
 def test_required_contexts_finds_a_context_it_is_given() -> None:
-    # Pre-flight the reader, or a change that stops it matching reports green over a file full of
-    # retired names — the conventions layer's rule for a table reader, applied to this one.
     given: Doc = {
         "rules": [
             {
@@ -38,9 +35,7 @@ def test_required_contexts_returns_nothing_for_a_ruleset_with_no_such_rule() -> 
 
 
 def test_composed_contexts_finds_the_contexts_the_tree_actually_reports() -> None:
-    # Pre-flight the composer against the tree by name, per the conventions layer: a composer that
-    # stops reading `uses:` would otherwise report green over every retired name at once. These four
-    # are confirmed against this repository's own reported check-run names, not guessed.
+    # These four are confirmed against this repository's own reported check-run names, not guessed.
     contexts = {c.context for c in composed_contexts()}
     assert "ci / python-ci" in contexts
     assert "commits / pr-title" in contexts
@@ -75,9 +70,7 @@ def test_the_unresolved_message_names_the_ruleset_the_context_and_what_to_do() -
 
 
 def test_cannot_judge_is_set_by_name_for_the_contexts_that_cannot_be_required() -> None:
-    # Pre-flight against the tree by name: each reason has a different cause, and a composer that
-    # stops reading any one of them would report green over exactly the context that reason exists
-    # to catch.
+    # One context per reason, so dropping any single reason fails here rather than only where it counts.
     by_context = {c.context: c.cannot_judge for c in composed_contexts()}
     assert by_context["advisory / prek-advisory"] is not None
     assert by_context["describe / pr-description"] is not None
@@ -89,9 +82,8 @@ def test_cannot_judge_is_set_by_name_for_the_contexts_that_cannot_be_required() 
 
 
 def _cannot_be_required(ruleset_name: str, context: str, reason: str) -> str:
-    # FR-009, principle VII made structural: a required context that reports green without judging
-    # anything is a required gate nobody would ever see fail. The reason is quoted, not summarised,
-    # so the message is the record of why this one is exempt.
+    # FR-009, principle VII made structural. The reason is quoted rather than summarised, so the
+    # message says which of the several causes applied.
     return (
         f"{ruleset_name} requires {context!r}, which cannot judge anything: {reason}. "
         f"Remove it from .github/rulesets/{ruleset_name}.json — a required gate never passes "
@@ -100,9 +92,6 @@ def _cannot_be_required(ruleset_name: str, context: str, reason: str) -> str:
 
 
 def test_a_call_that_switches_a_check_off_cannot_judge_the_context_it_composes() -> None:
-    # The half `skips_under` documents in prose and no gate held: `conventional-commits` says of its own
-    # `check-title` input that switching it off skips the job and a skipped job reports success. The
-    # composer reads the caller's `with:` against the called job's `if:`, so the prose is now a gate.
     reason = switched_off(
         {"uses": "$/.github/workflows/conventional-commits.yml", "with": {"check-title": False}},
         "conventional-commits",
@@ -167,9 +156,7 @@ def test_the_cannot_be_required_message_quotes_the_reason() -> None:
 
 
 def test_a_context_the_tree_composes_but_does_not_require_causes_no_failure() -> None:
-    # Not every check is a gate. Requiring more is a maintainer's decision, not this gate's —
-    # spec.md Story 2, scenario 4. `advisory / prek-advisory` is composed and, deliberately, is not
-    # in the required list: its presence here asserts nothing failed above it.
+    # Not every check is a gate: requiring more is a maintainer's decision, not this gate's.
     composed = {c.context for c in composed_contexts()}
     required = {context for doc in ruleset_docs().values() for context in required_contexts(doc)}
     assert "advisory / prek-advisory" in composed - required

--- a/tests/test_workflow_properties.py
+++ b/tests/test_workflow_properties.py
@@ -202,8 +202,8 @@ def apply_steps() -> list[Doc]:
 
 
 def test_the_applier_is_reachable_by_dispatch_and_a_schedule_alone() -> None:
-    # FR-003. A ruleset write has no revert, and a push or a merge trigger here would apply whatever
-    # the tree said at that commit before anyone had read the difference.
+    # FR-003. A push or a merge trigger would apply whatever the tree said at that commit, before
+    # anyone had read the difference, and a ruleset write has no revert.
     reached_by = set(triggers(load(WORKFLOW_DIR / "apply-ruleset.yml")))
     assert reached_by == {"workflow_dispatch", "schedule"}, (
         f"apply-ruleset is reachable from {sorted(reached_by)}. Applying is a human act, and the "
@@ -212,9 +212,8 @@ def test_the_applier_is_reachable_by_dispatch_and_a_schedule_alone() -> None:
 
 
 def test_every_ruleset_writing_step_is_gated_on_the_event_the_dry_run_and_the_verdict() -> None:
-    # The dispatch-only half of FR-003, which the trigger set above no longer holds on its own. Each
-    # of the three is a one-word deletion away from a cron that writes, a dry run that writes, or a
-    # write with nothing decided — and none of the three would look like anything in review.
+    # The dispatch-only half of FR-003, which the trigger set alone no longer holds. Deleting any one
+    # of the three clauses gives a cron that writes, a dry run that writes, or a write over a refusal.
     found = 0
     for step in apply_steps():
         if SENDS_A_BODY not in str(step.get("run", "")):
@@ -241,9 +240,8 @@ def test_every_ruleset_writing_step_is_gated_on_the_event_the_dry_run_and_the_ve
 
 
 def test_the_scheduled_read_fails_on_any_verdict_but_nothing() -> None:
-    # The drift alarm, and the one thing that makes the tree authoritative rather than aspirational.
     # A condition that stops matching leaves a scheduled run reporting success over a live ruleset
-    # nobody is applying — green, having judged nothing.
+    # nobody is applying.
     alarm = [step for step in apply_steps() if step.get("id") == "drift"]
     assert len(alarm) == 1, (
         "apply-ruleset names no step `drift`, so nothing reports that the live ruleset stopped "


### PR DESCRIPTION
## What changed

`T017` ticked, the feature's last open task, with the verification recorded in the log.

`apply-ruleset.yml` now states what satisfies its `administration: write` demand: the App behind its
secrets must hold the permission, and an installation has to accept a permission before it takes effect.

A comment in `rulesets.py` claiming `tests/capabilities.py` co-owned `WRITABLE_FIELDS`, and that neither
module imports the other, was left standing when that duplicate was removed — the suite now imports the
module it said it could not. Corrected, with a pass over the feature's remaining comments for prose that
restated the code or argued for a decision rather than stating the rule behind it. Net 16 comment lines
fewer, no behaviour touched.

## Why?

The permission demand was in the tree and what satisfies it was not. Its absence surfaces as a `422`
naming neither the App nor the installation, which is not diagnosable from the failure.

The stale comment is the defect the conventions layer names directly — stale framing, not a follow-up —
and it pointed a reader at the opposite of the arrangement now in the tree.

Closes #6

## Blast radius

nothing — internal only. No published capability, no check name, no consumer-visible surface. The
committed ruleset is unchanged, so nothing the default branch requires moves.

## Verification

`mise run ci` green: 115 passed, pyright 0 errors, ruff/actionlint/zizmor/yamllint/markdownlint/cspell
clean.

Beyond the suite, the feature was exercised against the live API before this PR: dry dispatch reported
nothing to change (run `34533773004`), and `create` and `update` both ran for real against a `disabled`
scratch ruleset targeting no existing branch, each verified field-for-field and returning `nothing` on
the following read, then deleted. `protect-default-branch` was untouched throughout — its `updated_at`
still predates the feature.

## Docs

`specs/002-ruleset-in-tree/tasks.md` as the work log. No shipped doc describes the applier's token, so
the fact sits at the demand it explains rather than in a new document.