### PR TITLE
docs: say which release carries the ruleset-in-tree spec

### DIFF
--- a/specs/002-ruleset-in-tree/spec.md
+++ b/specs/002-ruleset-in-tree/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-09-08
 
-**Status**: Draft
+**Status**: Merged 2026-09-10, in no release yet
 
 **Input**: Issue #6 — "codify the branch ruleset so a retired check name cannot pass unnoticed"
 


### PR DESCRIPTION
## What changed

`specs/002-ruleset-in-tree/spec.md` line 7: `Status: Draft` → `Status: Merged 2026-09-10, in no release yet`.

## Why?

`Draft` is what `.specify/templates/spec-template.md` ships as the starting value, and nothing tells a
reader when it should change — so it stayed after the feature merged. A spec whose tasks are all ticked
and whose work is on the default branch is not a draft, and this field is the one place that owns a spec's
own lifecycle.

Written as the fact rather than a lifecycle word: `Complete` would not say whether a consumer can resolve
any of it. And this feature is in **no** release — `git tag --contains f1410c5` is empty, `v0.1.0` predates
the merge by two days, and `v0.1.1` is proposed in #12 but unpublished. Naming a tag that does not exist
would be the same defect in a new form.

`specs/001-consumer-contract` has the same stale field and is genuinely in `v0.1.0`; it follows as a
separate PR.

## Blast radius

nothing — internal only. A spec directory is not authoritative for behaviour and no gate reads this field.

## Verification

`mise run ci` green: 115 passed, pyright 0 errors, all linters clean.

Facts checked rather than assumed: `git tag --contains f1410c5` (empty), `git ls-tree v0.1.0 .github/rulesets/`
(empty), `v0.1.0` tagged 2026-09-08 against a merge of 2026-09-10.

## Docs

This file only. The template is vendored and version-locked to the `pipx:specify-cli` pin, so its `Draft`
default is not ours to edit.

## Follow-up

This line needs one more touch when a release carries the feature. Two ways to avoid that being forgotten,
neither in this PR: release `v0.1.1` (#12) and amend it to `Shipped in v0.1.1`, or add a gate asserting no
spec with every task ticked still reads `Draft`.