### PR TITLE
docs: say which release carries the consumer-contract spec

### DIFF
--- a/specs/001-consumer-contract/spec.md
+++ b/specs/001-consumer-contract/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-09-07
 
-**Status**: Draft
+**Status**: Shipped in v0.1.0
 
 **Input**: User description: "Specify the consumer contract this repository is to provide: reusable GitHub Actions workflows and composite actions for turboBasic repositories. Derive it from the functional behaviour of ../github-actions, read only from .github/workflows/*.yml, actions/*/action.yml and the Python those actions run, plus README.md as the advertised contract."
 


### PR DESCRIPTION
## What changed

`specs/001-consumer-contract/spec.md` line 7: `Status: Draft` → `Status: Shipped in v0.1.0`.

## Why?

`Draft` is what `.specify/templates/spec-template.md` ships as the starting value, and nothing tells a
reader when it should change. Every one of this spec's 79 tasks is ticked, its five callable workflows have
been published since `v0.1.0`, and consumers resolve them today — so the one field that owns this spec's
lifecycle was the only thing in the tree still calling it a draft.

Named by release rather than by a lifecycle word: what a reader wants from a shipped spec is which ref
carries it, and `Complete` does not answer that.

Second of two; #17 does the same for `002-ruleset-in-tree`, which needed a different value because it is in
no release yet. Independent branches, both cut from `main`, so they can merge in either order.

## Blast radius

nothing — internal only. A spec directory is not authoritative for behaviour and no gate reads this field.

## Verification

`mise run ci` green: 115 passed, pyright 0 errors, all linters clean.

The version claim was checked rather than assumed: `031b020 feat: ship the consumer contract as five
callable workflows (#2)` is in `v0.1.0`, and `git ls-tree v0.1.0 .github/workflows/` lists all eleven
workflow files.

## Docs

This file only. The template is vendored and version-locked to the `pipx:specify-cli` pin, so its `Draft`
default is not ours to edit.