### PR TITLE
feat: add one check over what a change starts depending on

### DIFF
--- a/.cspell/project.txt
+++ b/.cspell/project.txt
@@ -27,6 +27,11 @@ tamasfe
 zizmorcore
 
 # --- Library and API identifiers ---
+# GitHub advisory ids and the OpenSSF Scorecard, both named by dependency-review-action's inputs;
+# NOASSERTION is SPDX's own token for a licence a package declares nothing about
+ghsas
+NOASSERTION
+OpenSSF
 pyupgrade
 rawfile
 schemafile

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -1,0 +1,18 @@
+name: 🌜 dependency-guard
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  # The job id composes the first half of the context: `guard / dependency-review`. Not required in
+  # this repository's own ruleset — an upstream advisory nobody has triaged must not block a merge.
+  guard:
+    permissions:
+      contents: read # the capability reads this repository's dependency-graph difference with it
+    uses: $/.github/workflows/dependency-review.yml

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,38 @@
+name: 🧩 dependency-review
+
+on:
+  workflow_call:
+    inputs:
+      fail-on-severity:
+        description: >-
+          The lowest advisory severity that reddens the check. Anything below it still appears in the
+          job summary and never fails the run.
+        type: string
+        default: low
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    # Registered in the surface fixture's skip table. There is no base and no head to difference under
+    # any other event, so there is nothing to judge.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read # the difference is read from the API with this token
+    steps:
+      - id: review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: ${{ inputs.fail-on-severity }}
+
+      # The action's own 403 already names the setting and its settings/security_analysis path; it
+      # cannot know that a called workflow has no way to switch that setting on for its caller, so this
+      # step says the one thing it doesn't. `dependency-changes` is set only once the comparison has
+      # actually been read, so this cannot fire on a run that failed over a real advisory.
+      - id: graph-off
+        if: failure() && steps.review.outputs.dependency-changes == ''
+        run: |
+          echo "::error::dependency-review could not read the dependency-graph difference for this repository. Check that Dependency graph is enabled at $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/settings/security_analysis — this capability cannot switch that setting on for you."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # turboBasic/github-actions
 
-Five reusable GitHub Actions workflows for `turboBasic` repositories. Every published capability is a
+Reusable GitHub Actions workflows for `turboBasic` repositories. Every published capability is a
 callable workflow: none is offered as a composite action a consumer places in a job it already owns.
 
 The work is staged at
@@ -297,6 +297,33 @@ CI without handing write access to your pull requests.
 
 **Pass the same `hook-stage` you pass to `python-ci`.** Different stages mean the two runs disagree
 about which checks apply, and the comment then reports on a set of hooks the blocking check never ran.
+
+### `dependency-review`
+
+Reads the dependency-graph difference between a pull request's base and its head, and reddens on an
+advisory at or above a severity floor. It is the only capability here judging what a change starts
+depending on rather than what it says.
+
+```yaml
+jobs:
+  guard:
+    permissions:
+      contents: read
+    uses: turboBasic/github-actions-new/.github/workflows/dependency-review.yml@v0.1
+```
+
+Required context: `guard / dependency-review` — your own job id, then the called job's name. It may be
+required only under `pull_request`: requiring it under any other event gives a check that reports
+success without reading anything, because there is no base and no head to difference.
+
+What reddens the check: an advisory at or above the severity floor. What only appears in the run's
+output and never fails anything: a finding below the floor, an OpenSSF Scorecard warning, and an
+unlicensed dependency — with no licence policy configured, a licence is reported and never refused;
+refusing a named licence is a second input this capability does not take.
+
+**Your repository's own dependency graph has to be switched on.** This capability cannot switch it on
+for you: with the setting off, the run fails naming it and the `settings/security_analysis` path to
+change it, and says it cannot make that change on your behalf.
 
 ## Versioning
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ exclude = [
   ".github/workflows/apply-ruleset.yml",
   ".github/workflows/ci.yml",
   ".github/workflows/commit-messages.yml",
+  ".github/workflows/dependency-guard.yml",
   ".github/workflows/describe-pr.yml",
   ".github/workflows/release-on-merge.yml",
   ".github/workflows/release-proposal.yml",

--- a/specs/004-dependency-review/checklists/requirements.md
+++ b/specs/004-dependency-review/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: What a change starts depending on
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-09-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The product here *is* continuous-integration configuration, so "callable workflow", "job",
+  "permission", "check name" and "event" are the consumer's own vocabulary rather than implementation
+  detail. No file path, tool name, action name, input name or version appears in the spec — those are
+  the plan's to choose, and FR-011 in particular is written to the outcome so the plan may reach it
+  another way.
+- One reading was resolved rather than asked: the brief fixes the interface at one input and puts
+  reinterpreting the published action's judgement out of scope, which settles that no licence policy is
+  exposed. The consequence — a licence finding informs and refuses nothing — is stated in Assumptions
+  and made a documented, gated fact by FR-013 rather than left implied. Making a licence refusal real is
+  a second input and a separate request.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/004-dependency-review/contracts/published-surface-delta.md
+++ b/specs/004-dependency-review/contracts/published-surface-delta.md
@@ -1,0 +1,67 @@
+# Contract: the published surface delta
+
+The only consumer-visible change in this feature. Everything else it does is a gate or a caller of its
+own, and neither promises anything to anybody outside this repository.
+
+This repository's interface is its capabilities: a reusable workflow's declared inputs, the permissions
+it demands, and the check names it composes. `tests/published_surface.toml` is the committed statement
+of all three and `tests/test_published_surface.py` holds the tree to it. That fixture is the contract
+document; this file records what changes in it and why.
+
+## What changes
+
+One capability arrives. Nothing else on the surface moves.
+
+| Capability | Kind | Inputs | Permission demand | Composed context | Break? |
+| --- | --- | --- | --- | --- | --- |
+| `dependency-review` | workflow, published | `fail-on-severity` | `contents: read` | `<caller job id> / dependency-review` | no |
+
+Its `tool_prerequisites` list is empty, and empty is true: it provisions no task runner and invokes no
+tool a consumer's own configuration has to pin. Its `skips_under` carries one entry — the job does no
+work under any event but `pull_request`.
+
+`judges` is absent, so true. This is the third published workflow whose context a consumer may require,
+alongside `python-ci` and `conventional-commits`, and it is required under `pull_request` or not at all.
+
+## What does not change
+
+| Considered | Verdict |
+| --- | --- |
+| every other capability's inputs, defaults, permissions and check names | byte-identical — the surface gate compares all of them on every run |
+| the committed branch ruleset's required contexts | unchanged; the new context is composed and not required |
+| `[tool.turbobasic-release].include` | unchanged; the capability is consumer surface and already inside it |
+
+## Why this is not a break
+
+A consumer resolving the ref they already pin gets a file they do not call. Nothing they name is
+renamed, no default they rely on moves, and no permission they must grant is raised — the three edits
+principle IV says a consumer cannot absorb. Adding surface is absorbed by resolving the ref alone.
+
+The version this ships under is the release path's to decide from the range and the surface, not this
+feature's. What this change owes it is a truthful fixture in the same commit as the workflow, so the
+decision is reached from a tree that tells the truth.
+
+## What the capability deliberately does not publish
+
+Each of these is an input the published action declares and this capability does not pass on. Listed
+because a surface is also what it refuses to expose, and because every one of them is a thing somebody
+will eventually ask for.
+
+| Not exposed | Why |
+| --- | --- |
+| `allow-licenses`, `deny-licenses`, `config-file` | a licence policy is a second input and a separate request; with none configured an unlicensed dependency is reported and no licence can be refused |
+| `comment-summary-in-pr` | `always` or `on-failure` demands `pull-requests: write`, which every caller would then have to grant before any job exists |
+| `warn-only` | a capability that always reports success is a required gate that never judges (principle VII) |
+| `allow-ghsas`, `deny-packages`, `deny-groups` | re-ranking or overriding the action's judgement, which this capability does not do |
+| `base-ref`, `head-ref`, `repo-token` | a consumer identifies nothing; all three are already in the run |
+| `timeout-minutes` | the runtime is one API comparison, not a function of the caller's tree — the job fixes its own |
+
+An input added here later is a surface addition and absorbable. Removing one is not, which is why the
+list starts at one.
+
+## Sequencing
+
+The fixture row, the workflow and the README section land together: a capability without its row fails
+the correspondence gate, and a row without its capability fails it from the other side. The caller and
+the release-surface exclusion can land in the same change or a later one — they are this repository's own
+call site and promise nothing to anybody.

--- a/specs/004-dependency-review/data-model.md
+++ b/specs/004-dependency-review/data-model.md
@@ -1,0 +1,138 @@
+# Data model: the artefacts this feature adds and moves
+
+There is no application and no store. The entities are files, and the relationships between them are
+what the suite reads. Each entity below names the file that owns it, so nothing here is a second copy
+of a fact the tree holds.
+
+## The capability
+
+`.github/workflows/dependency-review.yml`, new.
+
+| Property | Value | Held by |
+| --- | --- | --- |
+| Workflow name | `🧩 dependency-review` | `tests/test_names.py` |
+| Trigger | `workflow_call`, and nothing else | `is_call_only`, via the name gate |
+| Job id and name | `dependency-review` | `tests/test_names.py` |
+| Event handled | `pull_request`; the job's `if:` pins it | fixture `skips_under` + the skip gate |
+| Declared inputs | exactly `fail-on-severity`, `type: string`, `default: low` | `tests/published_surface.toml` |
+| Permission demand | `contents: read`, with its reason on the line | surface gate + the reason gate |
+| Timeout | a literal on the job; no input | the timeout gates + the schema hook |
+| Steps | the pinned action, then one diagnostic gated on failure | the new gates below |
+
+The `permissions:` block is at job level only, and workflow level is `{}` — the shape `python-ci`
+already uses, so a caller reading the diff sees the whole demand in one place.
+
+## The published third-party action
+
+One step, `id: review`:
+
+```yaml
+uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+with:
+  fail-on-severity: ${{ inputs.fail-on-severity }}
+```
+
+`with:` carries that key and no other. Every other input the action declares stays unset, so the
+action's defaults are the policy: no licence lists, no denied packages, no allowed advisories, and
+`comment-summary-in-pr` left at `never`.
+
+## The diagnostic step
+
+Gated on `failure() && steps.review.outputs.dependency-changes == ''` — a failure in which the
+comparison was never read. Its `run:` block interpolates nothing and emits one `::error::` naming the
+setting, the path a consumer changes it at (built from `$GITHUB_SERVER_URL` and `$GITHUB_REPOSITORY`),
+and that this capability cannot switch it on for them.
+
+## The caller in this repository
+
+`.github/workflows/dependency-guard.yml`, new. `🌜 dependency-guard`, triggered on `pull_request`, its
+own concurrency group, workflow-level `permissions: {}`, one job:
+
+| Property | Value |
+| --- | --- |
+| Job id | `guard` |
+| Permission | `contents: read`, with its reason |
+| `uses:` | `$/.github/workflows/dependency-review.yml` — no ref, resolved at the commit under review |
+| Composed context | `guard / dependency-review` |
+
+## The published surface record
+
+`tests/published_surface.toml` gains one table. It is the first capability to arrive since the record
+existed, so this row is also the record's first use as what a new capability must arrive with:
+
+```toml
+[dependency-review]
+kind = "workflow"
+published = true
+check_name = ["dependency-review"]
+inputs = ["fail-on-severity"]
+permissions = { contents = "read" }
+tool_prerequisites = []
+
+[[dependency-review.skips_under]]
+jobs = ["dependency-review"]
+event = "any event but pull_request"
+reason = "…"
+```
+
+`judges` is absent, which means true: this capability's job reddens on a finding at or above the floor,
+unlike `prek-advisory` and `pr-description`. That is what makes the composed context required-eligible
+under `pull_request` — and this repository still does not require it.
+
+## The committed branch ruleset
+
+`.github/rulesets/protect-default-branch.json`, unchanged. Its three required contexts stay as they
+are. `guard / dependency-review` is composed and not required, and the existing gate that says a context
+the tree composes but does not require is no failure is extended to name it, so the absence is asserted
+rather than merely true.
+
+## The release surface declaration
+
+`pyproject.toml`, `[tool.turbobasic-release].exclude` gains `.github/workflows/dependency-guard.yml`,
+joining the seven callers already listed. The capability itself is consumer surface and stays inside
+`include`.
+
+## The consumer-facing reference
+
+`README.md` gains one `### dependency-review` section, positioned with the other capabilities, carrying:
+
+- a copyable call site pinning the moving ref, granting `contents: read` and passing nothing;
+- the composed context, `<your job id> / dependency-review`;
+- the one event the context may be required under, and that requiring it under another gives a check
+  that reports success without reading anything;
+- what reddens it, against what only appears in the output — sub-floor advisories, OpenSSF Scorecard
+  warnings and unlicensed dependencies — and that a licence is reported and never refused;
+- that the calling repository's dependency graph has to be on, and that this capability cannot switch it
+  on.
+
+The count in the opening line goes, rather than being incremented. No table in the section names a
+default; the existing README gate refuses one.
+
+## The gates
+
+New assertions in `tests/test_workflow_properties.py`, beside the other per-capability gates, each
+paired with a check that plants the violation:
+
+| Gate | Refuses | Requirement |
+| --- | --- | --- |
+| the capability's `uses:` set is one step whose slug is the action — the digest stays the workflow's | a checkout, a task-runner step | FR-002, FR-015 |
+| the action is given `fail-on-severity` and no other key | the pull request comment, a licence list | FR-007, FR-008 |
+| the `graph-off` step exists, is gated on failure and on an unread difference, and names the setting and the limit | an exit code as a result | FR-011, FR-024 |
+| every published input carries a description and an explicit default | an input whose behaviour when unset is unwritten | FR-004 |
+| the workflows excluded from the release surface are exactly the non-capabilities | a caller counted as consumer surface, silently | FR-018 |
+
+The last one is the only gate here that holds a fact outside the capability: `[tool.turbobasic-release]`
+is read at release time and nowhere else, so a caller missing from `exclude` has no symptom until it
+skews a version decision. The two sets are equal today, at seven each.
+
+Two existing assertions in `tests/test_ruleset_contexts.py` gain the new context by name: the reader
+pre-flight, and the composed-but-not-required case.
+
+One new reader in `tests/capabilities.py`, `declared_input_specs`, so the description-and-default gate
+reads the workflow through the suite's existing reader rather than parsing the YAML a second time.
+
+## What does not move
+
+Every other capability's file, check names, input names, defaults, permission demands and skip entries.
+The surface gate compares all of them on every run, so SC-006 is asserted by the suite rather than by a
+reviewer.

--- a/specs/004-dependency-review/plan.md
+++ b/specs/004-dependency-review/plan.md
@@ -1,0 +1,175 @@
+# Implementation Plan: One check over what a change starts depending on
+
+**Branch**: `004-dependency-review` | **Date**: 2026-09-12 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/004-dependency-review/spec.md`
+
+## Summary
+
+A sixth published capability: a call-only workflow that reads the dependency-graph difference between a
+pull request's base and its head and reddens on an advisory at or above a severity floor. It is the only
+thing in this library judging what a change starts depending on rather than what it says.
+
+One published action does the judging — `actions/dependency-review-action`, pinned to a digest, its own
+defaults left as the policy. The capability adds one input, demands one scope at read, checks nothing out,
+handles one event, and adds one thing the action cannot know: that a called workflow cannot switch on its
+caller's dependency graph. This repository becomes a real consumer of it at the commit under review, and
+deliberately does not require the context it composes.
+
+## Technical Context
+
+**Language/Version**: GitHub Actions workflow YAML; Python 3.14 for the gates only
+
+**Primary Dependencies**: `actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294`
+(`v5.0.0`) — the sole runtime dependency, and the only one. The gates add none
+
+**Storage**: N/A — `tests/published_surface.toml` is the committed surface record, not a store
+
+**Testing**: pytest, offline. The advisory scenario is exercised by hand, per
+[quickstart.md](quickstart.md)
+
+**Target Platform**: `ubuntu-latest` GitHub-hosted runners
+
+**Project Type**: library of reusable workflows. Nothing is published as an action
+
+**Performance Goals**: N/A. The job is one API comparison, which is why it takes no timeout input
+(FR-005) and fixes its own
+
+**Constraints**: `contents: read` and nothing more, at every block (FR-003); no checkout and no working
+tree read (FR-002); `mise run ci` never reaches the network (FR-023); no existing capability changes
+(FR-017)
+
+**Scale/Scope**: one new capability, one new caller, one fixture row, one README section, one new reader,
+five new gates, two existing gates extended by name. The consumer set is indefinite and is not recorded —
+compatibility is read from the surface
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.* Re-checked after Phase 1: no
+verdict changed.
+
+| Principle | Verdict | How this design holds it |
+| --- | --- | --- |
+| I. One Owner Per Fact | pass | The action's defaults are the policy, so no severity table or licence list is restated here. The README carries no input list and no default — the existing README gate refuses a `Default` column. The prose count of capabilities is **deleted** rather than incremented, because a count over a list of sections is a second owner of what the sections hold |
+| II. Secrets Never Persist | pass | No secret is named. `repo-token` defaults to `${{ github.token }}`, so no input carries it and nothing writes it anywhere |
+| III. Gates Are Never Loosened | pass | Zero exemptions, zero exclusion-list entries, zero relaxed tool settings (SC-005). The `[tool.turbobasic-release].exclude` line is not one of these: it says a workflow is this repository's own caller rather than consumer surface, which is exactly what it says about the seven callers already listed. FR-019 gets no gate, and research.md says why adding one and then exempting `ci / python-ci` would be an exclusion list arriving by the back door |
+| IV. What A Consumer Cannot Absorb Needs A New Line | pass | Surface is added and none moves. The fixture gate compares every other capability's inputs, defaults, permissions and check names on every run, so SC-006 is asserted rather than reviewed |
+| V. A Published Ref Cannot Be Withdrawn | pass | Nothing is tagged here. The version follows the release path's own reading of the range and the surface; what this change owes it is a truthful fixture in the same commit as the workflow |
+| VI. Caller-Controlled Text Never Reaches A Command Line | pass | The one `run:` block interpolates nothing at all — `$GITHUB_SERVER_URL` and `$GITHUB_REPOSITORY` are set by the runner. `test_no_interpolation.py` holds it |
+| VII. A Required Gate Never Passes Without Judging | pass | The job pins `pull_request` and its skip is registered in the surface record with its reason, so the existing skip gate admits it with no exemption. The capability judges — `judges` is absent — so the composed context is required-eligible under that one event, and the README says requiring it under another gives a check that reports success without reading anything |
+
+No violations, so **Complexity Tracking is empty** and stays deleted.
+
+One thing this section is *not* recording: an objection. The spec's opening promise covers licences and
+the shipped capability refuses none, because exposing a licence policy is out of the fixed interface. That
+is the spec's own assumption rather than a conflict, and FR-013 already makes the reference say so.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-dependency-review/
+├── plan.md                              # This file
+├── spec.md
+├── research.md                          # Phase 0: the action's real surface, and what it contradicts
+├── data-model.md                        # Phase 1: every artefact added or moved
+├── quickstart.md                        # Phase 1: how to validate, offline and on a real pull request
+├── contracts/
+│   └── published-surface-delta.md       # Phase 1: the only consumer-visible change
+├── checklists/
+│   └── requirements.md
+└── tasks.md                             # Phase 2 (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+.github/workflows/
+├── dependency-review.yml     # new — the capability. 🧩, workflow_call only, one input, one job
+└── dependency-guard.yml      # new — this repository's caller. 🌜, pull_request, job id `guard`
+
+.github/rulesets/
+└── protect-default-branch.json   # unchanged: the new context is composed and not required
+
+tests/
+├── capabilities.py               # + declared_input_specs, the one new reader
+├── published_surface.toml        # + the [dependency-review] table and its skip entry
+├── test_workflow_properties.py   # + four gates, each with its violation-planting check
+└── test_ruleset_contexts.py      # two existing assertions gain the new context by name
+
+README.md                         # + one capability section; the prose count deleted
+pyproject.toml                    # [tool.turbobasic-release].exclude gains the new caller
+.cspell/project.txt               # + OpenSSF, ghsas — already added, so this plan's own prose lints
+```
+
+**Structure Decision**: the layout is the repository's own and nothing about it is chosen here. A
+published capability is one file in `.github/workflows/`; a caller of it is another, one per capability,
+as `ci.yml`, `advisory.yml`, `commit-messages.yml` and `describe-pr.yml` already are. No `actions/`
+entry, because nothing here needs a composite action. Gates go beside the other per-capability gates in
+`test_workflow_properties.py` rather than into a new module — that file already holds the `python-ci`,
+`release`, `apply-ruleset`, `pr-description` and `conventional-commits` gates, and a module per capability
+would be a structure this repository does not have.
+
+## Phase 0 — what was open, and what closed it
+
+Full findings in [research.md](research.md). The four that changed the design:
+
+1. **`fail-on-severity` defaults to `low` in the action's schema, not in its `action.yml`.** The
+   capability declares `default: low` explicitly (FR-004) and that value is the action's own, so FR-008
+   holds. Consequence the README owes: at the default floor nothing is below the floor, so scenario 1.4 is
+   reachable only once a consumer raises it.
+2. **With no policy configured a licence finding is reported and refuses nothing** — the spec's edge
+   case is right. `unlicensed` is the one verdict reachable without an allow or deny list, and it is
+   the one that never calls `setFailed`. What no policy buys is the refusal, not the finding.
+3. **The action already names the setting and its URL on a 403.** Only the third clause of FR-011 is
+   missing, so the capability adds one step rather than translating a message upstream owns.
+4. **`dependency-changes` is set only once the comparison has been read**, which is the discriminator that
+   keeps the diagnostic off runs that failed on a real advisory.
+
+## Phase 1 — design
+
+[data-model.md](data-model.md) is the artefact-by-artefact statement;
+[contracts/published-surface-delta.md](contracts/published-surface-delta.md) is the contract, including
+the six inputs the capability deliberately does not expose and why each stays unexposed.
+
+The shape, in brief:
+
+```yaml
+# .github/workflows/dependency-review.yml
+name: 🧩 dependency-review
+on:
+  workflow_call:
+    inputs:
+      fail-on-severity: { type: string, default: low }   # description on the real thing
+permissions: {}
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    timeout-minutes: <literal>
+    permissions:
+      contents: read # reason on the line
+    steps:
+      - id: review
+        uses: actions/dependency-review-action@a1d282b… # v5.0.0
+        with:
+          fail-on-severity: ${{ inputs.fail-on-severity }}
+      - if: failure() && steps.review.outputs.dependency-changes == ''
+        run: echo "::error::…"
+```
+
+### Ordering, and what each step can land on its own
+
+| # | Lands | Green on its own because |
+| --- | --- | --- |
+| 1 | the capability + its fixture row + the README section | the correspondence gate fails either half alone, and the README is what makes the capability adoptable |
+| 2 | the four gates + the new reader | they read the capability from step 1; landing them first would be a suite asserting a partition the tree does not have |
+| 3 | the caller + the two extended context assertions + the release-surface exclusion and the gate that holds it | the context has to exist before a gate can name it |
+
+Steps 2 and 3 are independent of each other. Step 1 is P1 and P2 together — Story 2 is the permission
+surface, which is a property of the file Story 1 adds, not a second change. Story 3 is the README half of
+step 1 plus the fixture's skip entry. Story 4 is step 3.
+
+## Complexity Tracking
+
+No Constitution Check violation, so nothing is tracked here.

--- a/specs/004-dependency-review/quickstart.md
+++ b/specs/004-dependency-review/quickstart.md
@@ -1,0 +1,103 @@
+# Quickstart: validating the dependency-review capability
+
+Two halves. The first runs offline and is what CI runs; the second needs a real pull request, because a
+published advisory is not something the suite may reach for (FR-023).
+
+## Prerequisites
+
+```console
+mise run setup
+```
+
+## Offline: everything CI judges
+
+```console
+mise run ci
+```
+
+Passes with no network access (SC-001). What each part is asserting about this feature:
+
+| Command | Holds |
+| --- | --- |
+| `mise run lint` | actionlint and zizmor over both new workflows; the schema hook that refuses a job with no timeout; cspell over the new prose |
+| `mise run typecheck` | pyright strict over the new reader and the new gates |
+| `mise run test` | every gate below |
+
+### The gates to watch, and what each one is for
+
+```console
+uv run pytest tests/test_published_surface.py tests/test_workflow_properties.py \
+              tests/test_ruleset_contexts.py tests/test_names.py tests/test_action_pins.py -v
+```
+
+- `test_every_capability_in_the_tree_is_in_the_fixture` — the capability and its row arrive together.
+- `test_every_permission_demand_matches_the_fixture` — the demand is `contents: read` and stays it
+  (SC-004).
+- `test_every_event_conditional_job_appears_in_the_skip_table_with_a_reason` — the `pull_request` pin is
+  registered with its reason, so principle VII's gate admits it with no exemption (SC-005).
+- `test_composed_contexts_finds_the_contexts_the_tree_actually_reports` — `guard / dependency-review` is
+  the context the tree really reports.
+- `test_a_context_the_tree_composes_but_does_not_require_causes_no_failure` — it is composed and absent
+  from the required set (SC-008).
+- the new gates named in [data-model.md](data-model.md#the-gates), each beside the check that plants its
+  violation.
+
+### Prove each new gate can fail
+
+A gate that has never been seen red is a gate nobody has read. Break one thing, run the suite, revert:
+
+| Edit | Expected failure |
+| --- | --- |
+| add `comment-summary-in-pr: always` to the action's `with:` | the input gate, naming the permission every caller would then have to grant |
+| add an `actions/checkout` step to the capability | the `uses:` gate, naming why the difference is read from the API |
+| delete the diagnostic step | the diagnostic gate, saying a run that read nothing would fail with the API's own refusal |
+| raise the permission to `pull-requests: write` | the surface gate, naming the demand and the record it disagrees with |
+| drop `default: low` from the input | the description-and-default gate |
+| remove `dependency-guard.yml` from `[tool.turbobasic-release].exclude` | the release-surface gate, naming the caller counted as consumer surface |
+| rename the `graph-off` step's id | the diagnostic gate, naming the step it looked for — not a green run over a missing diagnostic |
+| add `guard / dependency-review` to the committed ruleset | nothing — it judges, so it is required-eligible; FR-020 is a maintainer's choice, and the composed-but-not-required gate is what records it |
+
+That last row is the one worth reading twice: the suite does not refuse a maintainer who later decides to
+require this context. It records that today's tree does not.
+
+## Online: the capability actually judging
+
+Nothing here is automated and nothing here is in `mise run ci`.
+
+### The failing case (Scenario 1.1, SC-003)
+
+1. In a repository whose dependency graph is on, add the call site from the README.
+2. Open a pull request adding a dependency version carrying a known advisory at or above `low`.
+3. Expected: the check reddens, and the run's log and job summary name the advisory, the package and the
+   version.
+
+### The passing cases (Scenarios 1.2, 1.3)
+
+- The same pull request moved to a version with no advisory → the check passes.
+- A pull request touching no dependency manifest → the check passes, having read an empty difference. The
+  log says `No Dependency Changes found`.
+
+### The floor (Scenario 1.4)
+
+At the default floor there is nothing below it — `low` is the lowest severity there is. To see a finding
+inform rather than fail, pass `fail-on-severity: high` and open a pull request whose only finding is
+`moderate`: the check passes and the finding appears in the job summary.
+
+### Adoption cost (Story 2, SC-002)
+
+Copy the call site unchanged, grant `contents: read`, change nothing else, fill in no value. The run
+starts and the check reports. Granting nothing at all is the case worth trying once: the run fails before
+any job exists, with no log and no annotation — which is why the demand is published rather than
+discovered.
+
+### The dependency graph switched off (Scenario 3.3, SC-007)
+
+In a repository with the dependency graph off, open any pull request that calls the capability. Expected:
+the run fails carrying two annotations — the action's own, naming the setting and its
+`settings/security_analysis` path, and this capability's, saying it cannot switch it on for you. A
+maintainer learns what to change without opening this repository.
+
+### This repository as its own consumer (Story 4, SC-008)
+
+Open any pull request here. Expected: `guard / dependency-review` appears in the check list, reports, and
+is absent from the required set — so an upstream advisory nobody has triaged does not block a merge.

--- a/specs/004-dependency-review/research.md
+++ b/specs/004-dependency-review/research.md
@@ -1,0 +1,150 @@
+# Research: one check over what a change starts depending on
+
+Every unknown the brief left open, answered from the published action's own source at the digest this
+feature pins rather than from its documentation. Where the answer contradicts the spec, that is said
+here and the requirement it affects is named.
+
+## The published action
+
+**Decision**: `actions/dependency-review-action`, pinned to
+`a1d282b36b6f3519aa1f3fc636f609c47dddb294` — `v5.0.0`, the current release.
+
+**Rationale**: It is GitHub's own action for exactly this comparison, and the only one that reads the
+dependency-graph difference from the API rather than from a checked-out tree. FR-002's "no checkout"
+follows from the action's design rather than being imposed on it.
+
+**Alternatives considered**: A capability calling the comparison API itself. Rejected — it would be
+this repository holding a second opinion about severity ranking and licence policy, which FR-008
+forbids, and there is no third judgement to make.
+
+## What the action reads and what it demands
+
+| Question | Answer, read from the source at the pinned digest |
+| --- | --- |
+| Permission | `contents: read`. Every call site in the action's own README grants that and nothing else |
+| Token | `repo-token` defaults to `${{ github.token }}`, so no input names it and no secret is passed |
+| Refs | `base-ref` and `head-ref` default from the `pull_request` payload; nothing is read from a tree |
+| Runtime | one API comparison and one summary render, so it is not a function of the caller's tree — FR-005 |
+
+The permission is what makes the capability adoptable in one grant (Story 2). Nothing about the fork
+case needs handling: the difference is read with the run's own read-scoped token and no fork content is
+fetched or executed.
+
+## The severity floor
+
+**Decision**: declare one input, `fail-on-severity`, `type: string`, `default: low`.
+
+**Rationale**: `low` is the action's own default — its `action.yml` deliberately declares no default so
+that a configuration file cannot be overwritten, and the value lives in the action's schema as
+`SeveritySchema = z.enum(SEVERITIES).default('low')`. Keeping the action's name and the action's value
+is what makes FR-008 true rather than merely stated; a different default would be re-ranking a finding
+and a different name would be a second owner of a fact the action owns.
+
+**Consequence the reference has to carry**: at the default floor nothing is below the floor, because
+`low` is the lowest severity there is. Scenario 1.4 — a finding that informs rather than fails — is
+reachable only once a consumer raises the floor. The README says which way the input moves and what it
+buys, instead of implying the default already sorts findings into two piles.
+
+## Licences: the half of the opening promise that does not hold
+
+**Finding**: `license_check` defaults to `true`, so the licence pass runs with no policy configured —
+but of the three verdicts it can reach, only one is reachable without one.
+`getInvalidLicenseChanges` classifies each change into `forbidden`, `unresolved` and `unlicensed`, and
+with `allow` and `deny` both undefined the first two are unreachable: every branch that fills them is
+guarded on one list or the other, and `forbidden` needs a cache entry only a policy comparison sets.
+`unlicensed` is filled regardless — a dependency whose licence resolves to `NOASSERTION` or to nothing
+at all.
+
+Then in `printLicensesBlock`, `forbidden` and `unresolved` each call `core.setFailed`, while
+`unlicensed` reaches `printNullLicenses` alone and never sets `issueFound`. So a licence finding
+without a policy is real, appears in the log and the job summary, and **fails nothing** — exactly the
+spec's edge case, and the reason FR-013 asks the reference to separate the two lists rather than to
+deny the first one exists.
+
+What no policy buys is the *refusal*: a licence this project will not accept cannot be named, so it
+cannot be blocked. That is the half of the opening promise that does not hold, and it is narrower than
+"no licence is judged". The README says an unlicensed dependency is reported and not refused, and that
+refusing a named licence is a second input.
+
+## What else only reports
+
+`show-openssf-scorecard` defaults to true and `warn-on-openssf-scorecard-level` to `3` — declared with
+no default in `action.yml` and defaulted in the schema, as `fail-on-severity` is, and spelled
+`show_openssf_scorecard` and `warn_on_openssf_scorecard_level` there. A dependency with a low OpenSSF
+Scorecard score produces a warning annotation and a summary row and fails nothing. FR-013 asks the
+reference to separate what reddens the check from what only appears in the output; this belongs on the
+second list beside sub-floor advisories and unlicensed dependencies, or the list is incomplete and a
+consumer reads a warning as a refusal that did not happen.
+
+## Naming the dependency-graph failure
+
+**Decision**: the action's own message carries two of the three clauses FR-011 demands. On a 403 it
+emits `Dependency review is not supported on this repository. Please ensure that Dependency graph is
+enabled, see <server>/<owner>/<repo>/settings/security_analysis` — the setting and where to change it.
+It cannot know the third clause, that a called workflow cannot change its caller's repository settings.
+So the capability adds one step that says it.
+
+**How the step knows**: `dependency-changes` is set only after the comparison has been read. A 403 or a
+404 throws before it, so the output is never set. A run that failed with that output empty is a run
+that judged nothing, and that is the honest discriminator — read from the action's own behaviour rather
+than from a message string that upstream may reword.
+
+```yaml
+- if: failure() && steps.review.outputs.dependency-changes == ''
+```
+
+**Alternatives considered**:
+
+- **Pre-flighting the API.** Rejected by the spec's own assumption, and it would repeat the very call
+  the action makes.
+- **Annotating on any failure.** Rejected: it would tell a maintainer to check a repository setting
+  when what actually happened is that an advisory was found, which is worse than saying nothing.
+- **Matching the action's message text.** Rejected: it pins this repository to a string upstream owns,
+  and the failure mode is silence.
+
+The step interpolates nothing. `$GITHUB_SERVER_URL` and `$GITHUB_REPOSITORY` are set by the runner, so
+principle VI holds structurally rather than by review.
+
+## Naming, so the composed context reads
+
+**Decision**: capability `dependency-review.yml`, job `dependency-review`; caller
+`dependency-guard.yml`, job `guard`. The composed context is `guard / dependency-review`.
+
+**Rationale**: FR-009 fixes the workflow name as its marker and its stem, and FR-019 wants the two
+halves of the context to repeat no word. `guard` names the caller's role, the way `ci`, `commits`,
+`describe` and `advisory` already do, and shares nothing with `dependency` or `review`.
+
+**Alternatives considered**: `deps / dependency-review` reads as a stutter even though the words
+differ. Adding the job to the existing `advisory.yml` would have been one file fewer, but that file
+means "reports and never fails" — `prek-advisory` is registered `judges = false` — and this capability
+does judge. One caller per capability is the pattern already in the tree.
+
+## FR-019 is a choice here, not a gate anywhere
+
+A gate asserting no composed context repeats a word across its halves would fail on `ci / python-ci`,
+which is shipped, required, and cannot be renamed without blocking every pull request that requires it
+(principle IV). So FR-019 is held by the name chosen in this change and by review, and no gate is added
+for it. Said here because the alternative reading — add the gate, then exempt the existing context — is
+principle III's exclusion list arriving by the back door.
+
+## Two things the spec does not name that this change owes
+
+- **`[tool.turbobasic-release].exclude` gains the new caller.** That list is where this repository says
+  which of its workflows are its own call sites rather than consumer surface; seven are already there.
+  Omitting the eighth would make a later edit to it count towards a break. This is not a loosened gate:
+  it is the same statement, for the same reason, as the seven beside it.
+- **The README's "Five reusable GitHub Actions workflows" is deleted rather than corrected to six.** A
+  count in prose over a list of sections is a second owner of a fact the sections already hold
+  (principle I), and it has to be edited by hand every time a capability lands. Deleting it satisfies
+  FR-016 with nothing left to drift and no gate to add.
+
+## What this change does not owe
+
+**No decision record.** The conventions layer sends versioning, permissions policy and pinning rules to
+a record first. This feature decides none of them: it applies the pinning rule the tree already holds,
+demands the permission scope four capabilities already demand, and leaves the version to the release
+path. Nothing here is expensive to reverse.
+
+**No technical-debt row.** The licence gap is a scope decision the spec records as an assumption and the
+README states as a limit, and the debt ledger takes only what nobody is going to do. A licence policy
+input is a separate request, which is an issue if anyone wants it.

--- a/specs/004-dependency-review/spec.md
+++ b/specs/004-dependency-review/spec.md
@@ -1,0 +1,300 @@
+# Feature Specification: One check over what a change starts depending on
+
+**Feature Branch**: `004-dependency-review`
+
+**Created**: 2026-09-12
+
+**Status**: Implemented 2026-09-12, not yet merged
+
+**Input**: User description: "A pull request that introduces a dependency carrying a known advisory, or a licence this project will not accept, is refused before it merges. Nothing in this library does that today."
+
+## User Scenarios & Testing *(mandatory)*
+
+Two readers. The **consumer** maintains another `turboBasic` repository, pins a ref of this one and
+types check names into a ruleset; they never read this tree. The **maintainer** works here. Every
+capability this library publishes today judges the code in a change; none judges what the change starts
+depending on, and the update bots do not fill the gap — they propose upgrades for dependencies a
+repository already has, on their own schedule, and say nothing about the one being added right now,
+which is the moment the decision is cheapest to reverse and the only moment anybody is looking at it.
+
+### User Story 1 - An advisory is refused before it merges (Priority: P1)
+
+A consumer's pull request adds a package. The version it adds carries a published advisory. Today every
+check on that pull request is green, because every check reads the diff's code and none reads what the
+diff added to the dependency graph. The consumer wants one check that reads the difference between the
+pull request's base and its head, judges it against the advisory database, and reddens.
+
+**Why this priority**: It is the entire capability. Nothing else in this story set has value without
+it, and no other capability here covers the gap.
+
+**Independent Test**: Callable on its own. Open a pull request in a repository that calls it, adding a
+dependency version with a known advisory, and confirm the check fails naming the advisory; move to a
+version with none and confirm it passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository calling the capability from a `pull_request` workflow, **When** the pull
+   request adds a dependency version carrying an advisory at or above the severity floor, **Then** the
+   check fails and the log names the advisory, the package and the version.
+2. **Given** the same repository, **When** the pull request adds a dependency version carrying no
+   advisory, **Then** the check passes.
+3. **Given** a pull request touching no dependency manifest at all, **When** the check runs, **Then**
+   it passes, having read a difference that is empty.
+4. **Given** a pull request whose only finding is below the severity floor the call site set, **When**
+   the check runs, **Then** it passes and the finding appears in the run's output rather than as a
+   failure.
+
+---
+
+### User Story 2 - Adopting it costs one permission (Priority: P1)
+
+A consumer copies one call site out of the consumer-facing reference, grants one permission, and has the
+check reporting. They grant no write access to their pull requests, and they identify nothing — no
+token, no pull request number, no repository, no commit range.
+
+**Why this priority**: A called workflow's permission demand is validated before any job exists, so a
+capability demanding more than it needs forces every caller to grant it, with no log and no annotation
+if they do not. The permission surface is the adoption cost, and this story is what keeps it at one
+scope at read. It ships with Story 1 or nobody can take the capability.
+
+**Independent Test**: Copy the published call site into a repository unchanged, grant nothing beyond
+what it names, and confirm the run starts and the check reports.
+
+**Acceptance Scenarios**:
+
+1. **Given** the call site as published, **When** a consumer grants `contents: read` and nothing else,
+   **Then** the run starts and the check reports.
+2. **Given** the capability, **When** its whole permission demand is read across every block it
+   declares, **Then** it is exactly `contents: read`, and no block anywhere asks for write access to
+   pull requests.
+3. **Given** the capability, **When** its steps are read, **Then** none checks the repository out and
+   none reads a working tree: the difference is read from the API.
+4. **Given** the capability, **When** its declared inputs are read, **Then** there is exactly one — the
+   severity floor at which a finding fails rather than informs — carrying a description and an explicit
+   default.
+
+---
+
+### User Story 3 - It is honest about what it does not judge (Priority: P2)
+
+A consumer reads the reference to decide whether to require the check in a ruleset. They learn the one
+event it handles, that it reports success without reading anything under any other, what it fails on,
+what it only reports, and that their repository's dependency graph has to be on. None of that is
+something a first run teaches them.
+
+**Why this priority**: A skipped job reports success, and a green check is the one nobody investigates
+(principle VII). The capability is required-eligible under one event and misleading under every other,
+and the difference has to be written down where the other capabilities' skip conditions are written
+down. It is P2 rather than P1 because a consumer who copies the published call site verbatim is already
+on the right event.
+
+**Independent Test**: Read the published surface record and the consumer-facing section against the
+capability's own YAML, and confirm the skip, its event and its reason are declared and agree.
+
+**Acceptance Scenarios**:
+
+1. **Given** the capability's job, **When** it is reached from any event but `pull_request`, **Then** it
+   does no work — and that skip, its event and its reason are registered in the published surface
+   record, so the existing gate over event-conditional jobs accepts it without an exemption.
+2. **Given** the consumer-facing reference, **When** a consumer reads this capability's section,
+   **Then** it says which event the composed context may be required under, and that requiring it under
+   another gives a gate that passes without reading anything.
+3. **Given** a calling repository whose dependency graph is switched off, **When** the check runs,
+   **Then** the run fails and names the setting, where the consumer changes it, and that this capability
+   cannot switch it on for them.
+4. **Given** the consumer-facing reference, **When** a consumer reads what the check fails on, **Then**
+   it distinguishes the finding that reddens the check from the finding that only appears in the run's
+   output, and does not promise a refusal the capability does not make.
+
+---
+
+### User Story 4 - Called here, required nowhere (Priority: P3)
+
+A dependency landing here gets the same look as a consumer's, so this repository calls the capability at
+the commit under review. But an advisory nobody has triaged yet must not block a merge, so the composed
+context reports and is not a required check, and the branch ruleset does not name it.
+
+**Why this priority**: It is what makes this repository a real consumer of its own capability rather
+than a describer of it, and it is the cheapest of the four to get wrong in the direction that hurts —
+naming the context in the ruleset would let an upstream advisory nobody has read block every pull
+request here. It ships last because Stories 1 to 3 are what a consumer receives.
+
+**Independent Test**: Open any pull request here and confirm the context appears, reports, and is absent
+from the required set; then confirm the suite passes with a context composed but not required.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pull request in this repository, **When** the checks are listed, **Then** the composed
+   context appears and reports.
+2. **Given** the committed branch ruleset, **When** its required contexts are read, **Then** this
+   context is not among them, and the suite passes with it composed but not required.
+3. **Given** the calling job's identifier, **When** it is joined to the called job's name to compose
+   the context, **Then** the two halves repeat no word.
+4. **Given** the calling workflow, **When** its permissions are read, **Then** it grants exactly what
+   the capability demands and nothing more.
+
+---
+
+### Edge Cases
+
+- **The calling repository's dependency graph is off.** It is a repository setting, not something a
+  call site can pass. The run cannot succeed, and the failure has to name the setting rather than
+  surface as an unexplained API refusal.
+- **The check is reached from an event other than `pull_request`.** There is no base and no head to
+  difference, so there is nothing to judge and the job does no work — which reports success.
+- **A consumer requires the context under an event the job skips.** The gate then passes without
+  reading anything; the reference says so, and the skip is registered where every other capability's
+  is.
+- **A finding sits below the severity floor.** It informs and does not fail. A consumer wanting it to
+  fail lowers the floor; nothing here re-ranks a finding.
+- **The pull request is from a fork.** The difference is read from the API with the run's own token
+  under `contents: read`; nothing about the fork's tree is checked out or executed.
+- **A licence finding with no policy for the published action to read.** It appears in the run's output
+  and fails nothing. This capability exposes no licence policy input and does not reinterpret the
+  published action's defaults, so the reference must say which half of the promise holds.
+- **The dependency graph has not finished computing for the head commit.** The published action's own
+  behaviour governs; this capability neither retries nor suppresses, and a consumer sees the action's
+  own message.
+- **A consumer wants the summary posted as a pull request comment.** That needs write access to pull
+  requests, which would force every caller to grant it. They fork this capability and ask for the
+  permission in a workflow that says so.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+The capability:
+
+- **FR-001**: A new capability MUST be published as a callable workflow whose only trigger is a
+  workflow call, composing exactly one check name, so a consumer requires one context: their own job
+  id, then that name.
+- **FR-002**: It MUST read the dependency-graph difference between the pull request's base and its
+  head, judged by a published third-party action. It MUST NOT check the repository out, and no step MUST
+  read a working tree.
+- **FR-003**: Its whole permission demand — the union of every block it declares — MUST be exactly
+  `contents: read`, with the reason written beside the grant. No block MUST ask for any level of access
+  to pull requests, and no future input MUST be able to raise the demand.
+- **FR-004**: It MUST declare exactly one input: the severity floor at or above which a finding fails
+  the check rather than informing. The input MUST carry a description and an explicit default.
+- **FR-005**: It MUST NOT declare a timeout input, because its runtime is one API-driven action rather
+  than a function of the caller's tree; its job MUST therefore fix its own timeout.
+- **FR-006**: The published action MUST be pinned to a full commit digest with its version written
+  beside the pin.
+- **FR-007**: The published action's summary-commenting behaviour MUST NOT be enabled, and no input
+  MUST expose it.
+- **FR-008**: The capability MUST NOT wrap, filter, re-rank or reinterpret the published action's
+  judgement. The action's own defaults are the policy.
+- **FR-009**: Its workflow name MUST be the call-only marker followed by its filename stem, and its job
+  name MUST be lowercase-kebab-case, so the existing name gates accept it unchanged.
+
+Honesty about what it cannot judge:
+
+- **FR-010**: Its job MUST do no work under any event but `pull_request`, and that skip, the event and
+  the reason MUST be registered in the published surface record, so the existing gate over
+  event-conditional jobs accepts it with no exemption (principle VII).
+- **FR-011**: When the run cannot read the difference because the calling repository's dependency graph
+  is off, the failure MUST name the setting, where the consumer changes it, and that this capability
+  cannot change it for them. An exit code, or the API's own refusal alone, is not a result.
+- **FR-012**: The consumer-facing reference MUST state the one event under which the composed context
+  may be required, and MUST state that requiring it under another gives a check that reports success
+  without reading anything.
+- **FR-013**: The consumer-facing reference MUST distinguish what reddens the check — an advisory at or
+  above the floor — from what only appears in the run's output, and MUST NOT promise a licence refusal
+  this capability does not make.
+
+Arriving on the published surface:
+
+- **FR-014**: The published surface record MUST gain this capability's row in the same change: its kind,
+  that it is published, the check name it composes, its one input name, its permission demand, its
+  empty tool-prerequisite list, and its skip entry.
+- **FR-015**: Its tool-prerequisite list MUST be empty and MUST be true: the capability MUST invoke no
+  tool the consumer's own configuration has to pin, and MUST provision no task runner.
+- **FR-016**: The consumer-facing reference MUST gain a section for it carrying a call site that can be
+  copied as it stands, the context it composes, and the permission demand as prose rather than as a
+  table naming a default. Any count or list of capabilities the reference states MUST be corrected in
+  the same change.
+- **FR-017**: No existing capability MUST change. No existing check name, input name, default,
+  permission demand or skip entry MUST move, so a consumer resolving the ref they already pin absorbs
+  this by resolving it alone (principle IV).
+
+This repository as its own consumer:
+
+- **FR-018**: A self-triggering caller workflow MUST call the capability on this repository's own pull
+  requests, resolving at the commit under review, granting exactly the demanded permission and no more.
+- **FR-019**: The calling job's identifier MUST be chosen so the composed context's two halves repeat no
+  word.
+- **FR-020**: The committed branch ruleset MUST NOT name the composed context. The context reports and
+  is not a required check, and the suite MUST pass with a context composed but not required.
+
+How every gate is held:
+
+- **FR-021**: Every gate already in the suite that has an opinion about a published capability MUST
+  have one about this capability, and MUST accept it with no exemption, no exclusion-list entry and no
+  relaxed tool setting (principle III).
+- **FR-022**: Any gate this feature adds MUST be paired with a check that plants the violation and
+  asserts the gate catches it, and MUST read the workflow through the suite's existing reader rather
+  than parsing the YAML a second time.
+- **FR-023**: The suite MUST stay offline. No gate added or amended here MUST require a network call or
+  a token.
+- **FR-024**: Every gate message added or amended here MUST name what was read, what it was compared
+  against, and what a maintainer should change.
+
+### Key Entities
+
+- **The capability**: a callable workflow that is the only thing in this library judging what a change
+  starts depending on. One input, one permission scope, one composed check name, one handled event.
+- **The published third-party action**: the thing that judges. Pinned to a digest, and its defaults are
+  the policy — this capability adds no opinion of its own.
+- **The published surface record**: the frozen statement of every capability's kind, inputs, permission
+  demand, composed check names, tool prerequisites and skips. This is the first capability to arrive
+  after it existed, so it is the first time the record is exercised as what a new capability must arrive
+  with rather than as a description of what was already there.
+- **The caller workflow in this repository**: makes this repository a real consumer at the commit under
+  review, rather than a describer of the capability.
+- **The committed branch ruleset**: what this repository requires of its own pull requests. It does not
+  name this context, and that absence is deliberate.
+- **The consumer-facing reference**: the one place a consumer reads a call site, the composed context,
+  and what the check will and will not refuse.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The full local gate run passes with no network access.
+- **SC-002**: A consumer adopts the check with two edits and no third: one copied call site, one granted
+  permission. Nothing else in their repository changes, and no value has to be filled in.
+- **SC-003**: A pull request adding a dependency version with an advisory at or above the floor fails
+  the check; the same pull request with the advisory below the floor, or with no advisory, passes.
+- **SC-004**: The capability's permission demand is one scope at read. Raising any scope to write, at
+  any block, fails the suite naming the demand and the record it disagrees with.
+- **SC-005**: The number of exemptions, exclusion-list entries and relaxed tool settings added to admit
+  this capability is zero.
+- **SC-006**: Every other capability's check names, input names, permission demands and skip entries are
+  byte-identical before and after this change.
+- **SC-007**: A maintainer whose run failed because the dependency graph is off learns the setting to
+  change from the run's own output, without opening this repository.
+- **SC-008**: The composed context appears on this repository's pull requests and is absent from the
+  required set of the committed ruleset.
+
+## Assumptions
+
+- **Licences are judged only as far as the published action judges them by default.** The brief fixes
+  the interface at one input and puts reinterpreting the action's judgement out of scope, so no licence
+  allow-list, deny-list or policy-file input is exposed. With no policy for the action to read, a
+  licence finding appears in the run's output and fails nothing — which is why FR-013 makes the
+  reference say so rather than repeat the opening promise. Making a licence refusal real is a second
+  input and a separate request.
+- **The severity floor keeps the published action's own input name and its own default.** Renaming it
+  would be this capability holding a second name for a fact the action owns, and choosing a different
+  default would be re-ranking a finding, which FR-008 forbids.
+- **The dependency-graph failure is named after the fact, not pre-flighted.** A pre-flight would repeat
+  the very API call the action makes, so the capability translates the failure it gets rather than
+  predicting it. This is the honest thing it can detect, and FR-011 is written to the outcome so the
+  plan may reach it another way.
+- **This repository's own dependency graph is available.** It is public, so the difference is readable
+  here and the caller in FR-018 reports rather than failing permanently.
+- **Adding a capability is not a break.** It adds surface without moving any, so a consumer resolving
+  the ref they already pin absorbs it by resolving it alone. The version this ships under follows this
+  repository's existing versioning rules and is not decided here.
+- **No dependency-update automation is in scope.** Proposing upgrades to dependencies a repository
+  already has is a separate concern with separate tooling, and lands as its own change.

--- a/specs/004-dependency-review/tasks.md
+++ b/specs/004-dependency-review/tasks.md
@@ -357,3 +357,56 @@ User Story 1 (T001–T003a) is the entire capability's value; Story 2 is a prope
 adds rather than a second change, and Story 3 is what makes the capability honest about what it does
 not judge and adoptable at all. So Phases 3–5 are one unit and one pull request, and Phase 6 is the
 only part that may follow.
+
+---
+
+## Phase 8: Convergence
+
+Every gate this feature added is in the tree and `mise run ci` is green, so nothing below changes what
+the capability does. What is unmet is FR-022 on two of the four new gates and FR-024 on one: a
+pre-flight that retypes the comparison rather than calling the gate's own reader asserts nothing about
+the gate, which is the failure the conventions layer names as *"Pre-flight the line out of the file,
+never a retyping of it."*
+
+- [X] T017 Make `test_the_with_key_check_would_catch_an_extra_key`
+  (`tests/test_workflow_properties.py:160`) plant the violation through the gate's own reader per FR-022
+  (partial). Today it builds a literal `{"fail-on-severity": ..., "comment-summary-in-pr": "always"}`
+  and asserts the set differs from `{ALLOWED_REVIEW_INPUT}` — a comparison of two literals that calls
+  no code the gate at `:151` uses, so a `review_with_keys` that stopped reading `with:` would report
+  green with this still passing. Give `review_with_keys` the step list as a parameter (as
+  `uses_slugs(steps)` already takes one) so the real gate passes `steps_of("dependency-review",
+  "dependency-review")` and the pre-flight passes a synthetic list carrying the `review` step with
+  `comment-summary-in-pr: always`, asserting the returned key set is what reddens. Mirror
+  `test_the_uses_slug_reader_refuses_a_checkout_beside_the_real_step` at `:125`, which is the shape this
+  file already gets right.
+
+- [X] T018 Make `test_the_input_spec_check_would_catch_a_missing_description`
+  (`tests/test_workflow_properties.py:182`) exercise the gate rather than a retyping of it per FR-022
+  (partial). The gate at `:166` holds its per-input check inline, so there is nothing for a pre-flight
+  to call: factor the two assertions into a helper taking a capability name and an input-name-to-spec
+  mapping and returning the list of complaints, have the gate call it over `declared_input_specs(doc)`,
+  and have the pre-flight call the same helper with a synthetic spec missing `description` and another
+  missing `default`, asserting it names each. Assert the real gate still returns an empty list over the
+  tree.
+
+- [X] T019 Pair `test_the_release_exclude_list_names_exactly_the_non_capability_workflows`
+  (`tests/test_workflow_properties.py:228`) with a violation-planting check per FR-022 (partial). It is
+  the one new gate that arrived with none, which is also what makes `data-model.md`'s gate table and
+  `quickstart.md`'s "each beside the check that plants its violation" untrue — and those live in a
+  completed `specs/` directory that is never edited again, so the gate is what has to become true. Its
+  set equality is two-sided, so factor out the comparison rather than the readers: a helper taking the
+  excluded set and the caller set and returning whether they agree, pre-flighted with a caller absent
+  from `exclude` and with a stale entry naming a workflow that is now a capability — the two directions
+  the gate's message already claims to catch. Both readers returning empty is the one state the equality
+  passes vacuously; assert the real caller set is non-empty so it cannot.
+
+- [X] T020 Move the remediation clause of `test_every_published_workflow_input_documents_itself`
+  (`tests/test_workflow_properties.py:179`) out of the comment and into the failure message per FR-024
+  (partial). The message is `"; ".join(missing)`, which names the capability, the input and which key is
+  absent but nothing a maintainer should change; the sentence FR-024's third clause wants — that an
+  input whose behaviour when unset is unwritten is a promise with nothing behind it, and that the fix is
+  a `description` and an explicit `default` on the input in its own workflow file — sits in the comment
+  at `:167` where no failing run prints it. Keep the comment's requirement citation.
+
+**Checkpoint**: `mise run ci` green, and each of the four gates this feature added can be shown red by
+a check in the suite rather than only by hand.

--- a/specs/004-dependency-review/tasks.md
+++ b/specs/004-dependency-review/tasks.md
@@ -260,7 +260,7 @@ reports on every pull request here and is absent from the required set.
   change, then revert. This is FR-022 exercised on the real files, over and above the pre-flights each
   gate carries in the suite.
 
-- [ ] T016 Work the "Online" section of [quickstart.md](quickstart.md) against a real repository: the
+- [X] T016 Work the "Online" section of [quickstart.md](quickstart.md) against a real repository: the
   failing case (SC-003), the passing cases, the floor at `fail-on-severity: high` (Scenario 1.4), the
   adoption cost with nothing granted (SC-002), the dependency-graph-off case (SC-007), and this
   repository as its own consumer (SC-008). Requires GitHub network access and is not part of

--- a/specs/004-dependency-review/tasks.md
+++ b/specs/004-dependency-review/tasks.md
@@ -1,0 +1,359 @@
+---
+
+description: "Task list for 004-dependency-review"
+---
+
+# Tasks: One check over what a change starts depending on
+
+**Input**: Design documents from `/specs/004-dependency-review/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [data-model.md](data-model.md),
+[contracts/published-surface-delta.md](contracts/published-surface-delta.md), [research.md](research.md),
+[quickstart.md](quickstart.md)
+
+**Tests**: This feature's tests are the gates themselves (pytest, offline) — not a separate test-first
+pass. Each implementation task below states the gate it must keep green or newly turn green. `.cspell/project.txt`
+already carries `OpenSSF` and `ghsas` from Phase 0 research and needs no further edit.
+
+## Phase 1: Setup
+
+None. No new dependency, tool, or scaffolding is introduced; every file this feature touches already
+exists in the tree.
+
+## Phase 2: Foundational
+
+None. The capability itself is User Story 1's deliverable — there is no shared infrastructure to stand
+up before it.
+
+---
+
+## Phase 3: User Story 1 - An advisory is refused (Priority: P1) 🎯 MVP
+
+**Goal**: Publish `.github/workflows/dependency-review.yml`, whose one job reads the pull request's
+dependency-graph difference through the pinned `actions/dependency-review-action` and reddens on an
+advisory at or above the severity floor.
+
+**Independent Test**: Copy the call site into a repository whose dependency graph is on, open a pull
+request adding a dependency version with a known advisory, and confirm the check fails naming the
+advisory, package and version (Scenario 1.1); move to a clean version and confirm it passes (1.2); open
+a pull request touching no manifest and confirm it passes on an empty difference (1.3). This is the
+"Online" half of [quickstart.md](quickstart.md) — not part of `mise run ci`.
+
+- [X] T001 [US1] Create `.github/workflows/dependency-review.yml`:
+  `name: 🧩 dependency-review`; `on: workflow_call:` declaring exactly one input,
+  `fail-on-severity` (`type: string`, `default: low`, with a description naming what it governs);
+  workflow-level `permissions: {}`; one job `dependency-review` (`runs-on: ubuntu-latest`,
+  `timeout-minutes: 5` as a literal — this capability takes no timeout input, per FR-005) with
+  job-level `permissions: { contents: read }` and the reason on the same line (matches the
+  `PERMISSION` regex in `tests/test_workflow_properties.py`, e.g.
+  `contents: read # the difference is read from the API with this token`); one step, `id: review`,
+  `uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0`, with
+  `with:` carrying only `fail-on-severity: ${{ inputs.fail-on-severity }}`. No `actions/checkout`
+  step, no `if:` yet (Phase 5/US3 adds the event pin and the diagnostic step in the same file).
+
+- [X] T002 [US1] Add the `[dependency-review]` table to `tests/published_surface.toml`, positioned
+  with the other capabilities: `kind = "workflow"`, `published = true`,
+  `check_name = ["dependency-review"]`, `inputs = ["fail-on-severity"]`,
+  `permissions = { contents = "read" }`, `tool_prerequisites = []`, `skips_under = []` (an empty list
+  is truthful until T007's `if:` exists; T008 **replaces** this line with an array-of-tables entry,
+  because TOML refuses a key defined both ways). Run
+  `uv run pytest tests/test_published_surface.py` and confirm
+  `test_every_capability_in_the_tree_is_in_the_fixture`,
+  `test_every_published_input_name_set_matches_the_fixture` and
+  `test_every_permission_demand_matches_the_fixture` pass.
+
+- [X] T003 [P] [US1] In `tests/test_workflow_properties.py`, add a gate asserting the capability's only
+  `uses:` is the pinned action (FR-002, FR-015): read the steps of job `dependency-review` in
+  `dependency-review.yml` (reuse the existing `steps_of(name, job_id)` helper already in this file),
+  collect every step's `uses:` value, and assert there is exactly one, whose slug — the part before
+  `@` — is `actions/dependency-review-action`. **Do not name the digest.** The workflow owns the pin
+  and `test_action_pins.py` owns whether it is a full SHA; repeating the digest here would make a pin
+  bump two edits with the suite as the thing that reddens, which is the second owner the surface
+  fixture refuses for defaults. The failure message must name what was found and that a checkout or a
+  task-runner step is what FR-002/FR-015 forbid.
+
+- [X] T003a [P] [US1] Beside T003's gate, add its pre-flight (FR-022): factor the slug-collecting
+  logic into a helper taking a step list, and assert it refuses a synthetic list carrying an
+  `actions/checkout@<sha>` step alongside the real one. The gate's steady state is a one-element set,
+  so without this a change that stopped the collector finding anything would report green over a
+  capability that checks the caller's tree out. Mirror the shape of
+  `test_the_permission_reader_tells_an_explained_grant_from_a_bare_one` in this file.
+
+**Checkpoint**: A pull request against a repository whose dependency graph is on and that calls this
+file directly now reddens on an advisory and passes otherwise. `mise run ci` is green.
+
+---
+
+## Phase 4: User Story 2 - Adopting it costs one permission (Priority: P1)
+
+**Goal**: Make the permission surface and the single input a property the suite asserts, not merely a
+property of how `dependency-review.yml` happens to be written today.
+
+**Independent Test**: Copy the published call site unchanged into a repository, grant `contents: read`
+and nothing else, and confirm the run starts and the check reports (Scenario 2.1). Read the capability's
+declared inputs and confirm there is exactly one, carrying a description and an explicit default
+(Scenario 2.4).
+
+- [X] T004 [P] [US2] In `tests/capabilities.py`, add a reader `declared_input_specs(doc: Doc) -> dict[str, Doc]`
+  returning, for each name in a workflow's `workflow_call.inputs`, the input's own mapping (so a caller
+  can check for `description` and `default` without a second YAML walk). Mirror the existing
+  `declared_inputs` function immediately above it in structure and docstring style.
+
+- [X] T005 [US2] In `tests/test_workflow_properties.py`, add a gate (FR-007, FR-008) asserting the
+  `with:` block of `dependency-review.yml`'s `review` step carries exactly the key `fail-on-severity`
+  and no other — refusing `comment-summary-in-pr`, `warn-only`, `allow-licenses`, or any other key the
+  action declares. Include a pre-flight assertion on the same helper/logic using a synthetic `with:`
+  dict containing `comment-summary-in-pr: always`, proving the gate would catch it, in the style of
+  `test_the_permission_reader_tells_an_explained_grant_from_a_bare_one` elsewhere in this file. The
+  failure message must name the keys found, the one key allowed, and — for `comment-summary-in-pr`
+  specifically — that `always` or `on-failure` demands `pull-requests: write`, which every caller would
+  then have to grant before any job exists (FR-024).
+
+- [X] T006 [US2] In `tests/test_workflow_properties.py`, add a gate (FR-004) asserting every input
+  declared by every *published* capability (read `fixture()` for `published == true` rows, `kind ==
+  "workflow"`) carries both a non-empty `description` and an explicit `default` key in the real
+  workflow YAML, via `declared_input_specs` from T004. Include a pre-flight test using a synthetic
+  input mapping missing `description`, proving the gate would catch it. The failure message must name
+  the capability, the input and which of the two keys is missing, and say that an input whose behaviour
+  when unset is unwritten is a promise with nothing behind it (FR-024). This gate is generic — it also
+  runs today against `python-ci`, `conventional-commits`,
+  `pr-description`, `release` and `prek-advisory`'s inputs, all of which already pass.
+
+**Checkpoint**: Granting only `contents: read` starts the run (already true from T001's job-level
+block and the existing generic `test_every_permission_demand_matches_the_fixture`); the two new gates
+now hold the single-input, no-extra-key shape as a property the suite defends rather than a fact that
+happens to be true today.
+
+---
+
+## Phase 5: User Story 3 - Honest about what it does not judge (Priority: P2)
+
+**Goal**: The job does no work under any event but `pull_request`, that skip is registered with its
+reason, a run that fails because the *caller's* dependency graph is off says so and says this capability
+cannot fix it, and the consumer-facing reference states all of this plus what only informs.
+
+**Independent Test**: Read `README.md`'s new section against `dependency-review.yml`'s own YAML and
+`tests/published_surface.toml`'s skip entry, and confirm the skip, its event and its reason agree
+(Scenario 3.1, 3.2). Open a pull request against a repository whose dependency graph is off and confirm
+the run fails naming the setting, the path to change it, and that this capability cannot change it
+(Scenario 3.3 — the "Online" half of quickstart.md).
+
+- [X] T007 [US3] In `.github/workflows/dependency-review.yml`, on the `dependency-review` job, add
+  `if: github.event_name == 'pull_request'` (FR-010). Add one further step after `review`,
+  `id: graph-off` — the id is what T009's gate finds it by, so the condition below stays owned by this
+  file alone — gated `if: failure() && steps.review.outputs.dependency-changes == ''` (the
+  discriminator research.md establishes: that output is set only once the comparison was actually
+  read), with a `run:` block that
+  interpolates nothing — building the settings path from `$GITHUB_SERVER_URL` and `$GITHUB_REPOSITORY`
+  — and emits one `::error::` naming the dependency-graph setting, that path, and that this capability
+  cannot switch it on for the caller (FR-011).
+
+- [X] T008 [US3] In `tests/published_surface.toml`, **delete the `skips_under = []` line T002 wrote**
+  under `[dependency-review]` and add in its place, after the table's other keys:
+
+  ```toml
+  [[dependency-review.skips_under]]
+  jobs = ["dependency-review"]
+  event = "any event but pull_request"
+  reason = "there is no base and no head to difference, so there is nothing to judge"
+  ```
+
+  Deleting the line is not tidying: TOML refuses a key defined as both an empty array and an array of
+  tables — `tomllib` raises `Cannot mutate immutable namespace ('dependency-review', 'skips_under')`,
+  which is a collection error rather than a test failure, so every gate reading `fixture()` errors at
+  once. The three rows that already carry skips — `conventional-commits`, `pr-description`,
+  `prek-advisory` — carry no `skips_under = []` line for the same reason.
+  Run `uv run pytest tests/test_workflow_properties.py::test_every_event_conditional_job_appears_in_the_skip_table_with_a_reason`
+  and confirm it passes now that T007's `if:` and this entry agree.
+
+- [X] T009 [US3] In `tests/test_workflow_properties.py`, add a gate (FR-011, FR-024) that finds the
+  diagnostic step added in T007 **by its `id: graph-off`**, asserts it exists exactly once, and then
+  asserts three things about the step as read from the file: that its `if:` names both `failure()` and
+  `steps.review.outputs.dependency-changes`, so the diagnostic cannot fire on a run that read the
+  difference and found a real advisory; and that its `run:` text names the dependency-graph setting and
+  says this capability cannot enable it. Do not locate the step by retyping the condition — a reworded
+  condition would then match nothing and the gate would report green over a missing diagnostic, which
+  is the failure mode research.md rejected for message-matching. Include a pre-flight test that feeds
+  the finder a synthetic step list with no `graph-off` id and asserts it reports the absence rather
+  than passing. The failure message must name the step it looked for, what it read in it, and what a
+  maintainer should add.
+
+- [X] T010 [P] [US3] Add a `### dependency-review` section to `README.md`, positioned with the other
+  capability sections (after `prek-advisory`, before `## Versioning`), carrying: a copyable call site
+  (`uses: turboBasic/github-actions-new/.github/workflows/dependency-review.yml@v0.1`, granting
+  `contents: read` and passing nothing); the composed context, `<your job id> / dependency-review`; that
+  it may be required only under `pull_request`, and that requiring it under any other event gives a
+  check that reports success without reading anything (FR-012); what reddens the check — an advisory at
+  or above the floor — against what only appears in the run's output — a sub-floor finding, an OpenSSF
+  Scorecard warning, an unlicensed dependency — and that with no policy configured a licence is
+  reported and never refused, so refusing a named licence is a second input (FR-013); and that
+  the calling repository's own dependency graph has to be switched on, which this capability cannot do
+  for it. Delete the opening line's dependency on a capability count — replace "Five reusable GitHub
+  Actions workflows" with prose that names no count (FR-016). No table in the new section may have a
+  column headed anything matching `default` (case-insensitive) — `test_no_readme_table_names_a_default`
+  already asserts this over the whole file.
+
+**Checkpoint**: `mise run ci` is green with the skip registered and the diagnostic in place. A run
+against a repository with its dependency graph off now fails naming the setting and this capability's
+limit. The README is the one place a consumer learns the one event and the two-list distinction.
+
+---
+
+## Phase 6: User Story 4 - Called here, required nowhere (Priority: P3)
+
+**Goal**: This repository calls the capability on its own pull requests at the commit under review, the
+composed context reports, and the committed ruleset does not require it.
+
+**Independent Test**: Open any pull request in this repository and confirm `guard / dependency-review`
+appears in the check list and reports (Scenario 4.1); read `.github/rulesets/protect-default-branch.json`
+and confirm that context is absent from `required_status_checks` (Scenario 4.2).
+
+- [X] T011 [US4] Create `.github/workflows/dependency-guard.yml`: `name: 🌜 dependency-guard`;
+  `on: pull_request:`; its own `concurrency:` group (`${{ github.workflow }}-${{ github.ref }}`,
+  `cancel-in-progress: true`, matching `advisory.yml`'s and `ci.yml`'s shape); workflow-level
+  `permissions: {}`; one job, `guard`, with job-level `permissions: { contents: read }` and the reason
+  on the same line, and `uses: $/.github/workflows/dependency-review.yml` — no `@ref`, no `with:`
+  (the default floor is fine for this repository's own consumer use). The composed context is
+  `guard / dependency-review`; the job id `guard` shares no word with `dependency-review` (FR-019).
+
+- [X] T012 [P] [US4] In `pyproject.toml`, add `".github/workflows/dependency-guard.yml"` to
+  `[tool.turbobasic-release].exclude`, alongside the seven callers already listed. Do not touch
+  `include` — the capability itself stays inside it.
+
+- [X] T012a [US4] In `tests/test_workflow_properties.py`, add a gate holding T012, because nothing
+  does today: read `[tool.turbobasic-release]` from `pyproject.toml` and assert that the set of
+  `exclude` entries under `.github/workflows/` equals exactly the set of workflows that are **not**
+  capabilities (`is_capability` is false — the `🌜` half of the tree). Set equality in both
+  directions: a new caller missing from `exclude` fails, and an entry naming a workflow that has since
+  become a capability fails too. The two sets are equal today at seven each, so the gate arrives green
+  and T012 turns it green again. The message must name which workflows are on which side, and say that a
+  caller left out of `exclude` makes a later edit to this repository's own call site count towards a
+  break. This
+  is the one fact this feature adds that only the release path reads, at release time — the failure
+  mode is silence, which is what earns it a gate rather than a note.
+
+- [X] T013 [US4] In `tests/test_ruleset_contexts.py`, extend
+  `test_composed_contexts_finds_the_contexts_the_tree_actually_reports` with
+  `assert "guard / dependency-review" in contexts` — and correct that test's own comment, which reads
+  "These **four** are confirmed against this repository's own reported check-run names": a count in a
+  comment over a list of assertions is the same drift T010 deletes from the README, so drop the number
+  rather than raise it. Extend
+  `test_a_context_the_tree_composes_but_does_not_require_causes_no_failure` with the same context
+  joining `"advisory / prek-advisory"` in the composed-but-not-required assertion. Do not edit
+  `.github/rulesets/protect-default-branch.json` — FR-020 requires it stay unchanged, and
+  `test_every_required_context_is_composed_by_the_tree` plus the two extended assertions are what prove
+  the absence is deliberate rather than accidental.
+
+**Checkpoint**: This repository is a real consumer of its own capability. `guard / dependency-review`
+reports on every pull request here and is absent from the required set.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T014 [P] Run `mise run ci` end to end (`mise run lint`, `mise run typecheck`, `mise run test`)
+  with no network access and confirm it passes (SC-001). `mise run lint` must be clean on both new
+  workflow files under actionlint, zizmor and the `check-workflow-timeouts` schema hook.
+
+- [X] T015 Work the "Prove each new gate can fail" table in [quickstart.md](quickstart.md) by hand: plant
+  each listed violation one at a time, confirm the named gate reddens with a message that names what to
+  change, then revert. This is FR-022 exercised on the real files, over and above the pre-flights each
+  gate carries in the suite.
+
+- [ ] T016 Work the "Online" section of [quickstart.md](quickstart.md) against a real repository: the
+  failing case (SC-003), the passing cases, the floor at `fail-on-severity: high` (Scenario 1.4), the
+  adoption cost with nothing granted (SC-002), the dependency-graph-off case (SC-007), and this
+  repository as its own consumer (SC-008). Requires GitHub network access and is not part of
+  `mise run ci`.
+
+---
+
+## Dependencies & Execution Order
+
+### What lands in one pull request
+
+Phases 3, 4 and 5 are **one change**, not three. plan.md's first landing step is the capability, its
+fixture row *and* its README section together, and
+[contracts/published-surface-delta.md](contracts/published-surface-delta.md) says the same from the
+other side: a capability with no row fails the correspondence gate, a row with no capability fails it
+too, and FR-014 requires the record to gain its skip entry in the same change as the skip. A merge
+after Phase 4 would publish a callable workflow with no consumer-facing reference and a fixture whose
+`skips_under` does not yet describe the job — truthful only because T007 has not landed either.
+
+Phase 6 may land in that change or a later one: the caller and the release-surface exclusion are this
+repository's own call site and promise nothing to anybody. Phase 7 runs before either merges.
+
+The phase boundaries below are checkpoints on the branch — points where `mise run ci` is green and the
+work so far is coherent — not merge points.
+
+### Phase Dependencies
+
+- **Setup, Foundational**: none — both are empty.
+- **User Story 1 (Phase 3)**: no dependency. Can start immediately.
+- **User Story 2 (Phase 4)**: depends on T001 (the file and its steps must exist for T003/T005/T006 to
+  read). Independent of Phase 5 and Phase 6.
+- **User Story 3 (Phase 5)**: depends on T001 and T002 (edits the same job and the same fixture row).
+  Independent of Phase 4 and Phase 6.
+- **User Story 4 (Phase 6)**: depends on T001 (the capability must exist for the caller to call and for
+  the context to compose). Independent of Phase 4 and Phase 5.
+- **Polish (Phase 7)**: depends on Phases 3–6 all being complete.
+
+### Within Each User Story
+
+- T001 before T002, T003 and T003a (US1). T003 before T003a — the pre-flight reads the helper the gate
+  is factored into.
+- T004 before T006 (US2) — the gate reads the reader. T005 has no dependency beyond T001.
+- T007 before T008 and T009 (US3) — the fixture entry and the gate both read the `if:` and the step
+  T007 adds.
+- T011 before T013 (US4) — the gate names a context that must already be composed.
+- T011 before T012, and both before T012a (US4). T012a's sets are equal today, so it would arrive green
+  on its own; once T011 adds an eighth caller it stays green only with T012 done, which is the whole
+  point of it.
+
+### Parallel Opportunities
+
+- T003 and T003a (US1's gate and its pre-flight) can run alongside T004–T006 (US2) and T011–T013 (US4)
+  once T001 exists — different
+  files, no ordering constraint between the stories themselves.
+- T010 (README) and T012 (`pyproject.toml`) touch files no other task in this feature touches, so they
+  are parallel-safe against everything except their own story's file-ordering above. T012a is not: it
+  reads both `pyproject.toml` and the workflow tree, so it goes last within US4.
+- T014 is parallel-safe with nothing — it is the checkpoint that everything else must precede.
+
+---
+
+## Parallel Example: after T001 lands
+
+```bash
+# US1's own gate, and the start of US2 and US4, all read the same file and no other:
+Task: "Add the uses: gate and its pre-flight in tests/test_workflow_properties.py (T003, T003a)"
+Task: "Add declared_input_specs in tests/capabilities.py (T004)"
+Task: "Create .github/workflows/dependency-guard.yml (T011)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. T001–T003a. Point a test repository's `pull_request` workflow at `dependency-review.yml` directly
+   (no ref needed within this repository's own checks) and confirm it reddens on a known advisory.
+2. **STOP and VALIDATE** against quickstart.md's Online section before continuing. This is a
+   checkpoint on the branch, not a merge — see *What lands in one pull request* above.
+
+### Incremental Delivery
+
+1. Phase 3 (US1) → the capability judges.
+2. Phase 4 (US2) → the permission and input surface are gate-defended, not just true today.
+3. Phase 5 (US3) → the skip is honest and registered; the dependency-graph-off failure names itself;
+   the README tells a consumer the truth.
+4. Phase 6 (US4) → this repository becomes a real consumer, deliberately not requiring the context.
+5. Phase 7 → full offline proof, then the online proof that cannot run in `mise run ci`.
+
+### Suggested MVP Scope
+
+User Story 1 (T001–T003a) is the entire capability's value; Story 2 is a property of the file Story 1
+adds rather than a second change, and Story 3 is what makes the capability honest about what it does
+not judge and adoptable at all. So Phases 3–5 are one unit and one pull request, and Phase 6 is the
+only part that may follow.

--- a/tests/capabilities.py
+++ b/tests/capabilities.py
@@ -208,6 +208,13 @@ def declared_inputs(doc: Doc) -> set[str]:
     return {str(name) for name in cast(Doc, call).get("inputs", {})}
 
 
+def declared_input_specs(doc: Doc) -> dict[str, Doc]:
+    # Each input's own mapping, so a caller can check for `description` and `default` without a
+    # second YAML walk.
+    call: Any = triggers(doc).get("workflow_call") or {}
+    return {str(name): cast(Doc, spec) for name, spec in cast(Doc, call).get("inputs", {}).items()}
+
+
 def action_inputs(doc: Doc) -> set[str]:
     return {str(name) for name in cast(Doc, doc.get("inputs", {}))}
 

--- a/tests/published_surface.toml
+++ b/tests/published_surface.toml
@@ -124,6 +124,19 @@ jobs = ["prek-advisory"]
 event = "any event but pull_request"
 reason = "there is no pull request to comment on. This capability is advertised as advisory rather than as a required gate, which is why principle VII exempts it by name — a consumer that requires this context has misread what it is for"
 
+[dependency-review]
+kind = "workflow"
+published = true
+check_name = ["dependency-review"]
+inputs = ["fail-on-severity"]
+permissions = { contents = "read" }
+tool_prerequisites = []
+
+[[dependency-review.skips_under]]
+jobs = ["dependency-review"]
+event = "any event but pull_request"
+reason = "there is no base and no head to difference, so there is nothing to judge"
+
 [ruleset-decisions]
 kind = "action"
 # Internal surface, for the same reason release-decisions is: no stability promise, no check name, and

--- a/tests/test_ruleset_contexts.py
+++ b/tests/test_ruleset_contexts.py
@@ -35,12 +35,13 @@ def test_required_contexts_returns_nothing_for_a_ruleset_with_no_such_rule() -> 
 
 
 def test_composed_contexts_finds_the_contexts_the_tree_actually_reports() -> None:
-    # These four are confirmed against this repository's own reported check-run names, not guessed.
+    # Confirmed against this repository's own reported check-run names, not guessed.
     contexts = {c.context for c in composed_contexts()}
     assert "ci / python-ci" in contexts
     assert "commits / pr-title" in contexts
     assert "commits / commit-messages" in contexts
     assert "propose" in contexts
+    assert "guard / dependency-review" in contexts
 
 
 def _unresolved(ruleset_name: str, context: str) -> str:
@@ -160,3 +161,4 @@ def test_a_context_the_tree_composes_but_does_not_require_causes_no_failure() ->
     composed = {c.context for c in composed_contexts()}
     required = {context for doc in ruleset_docs().values() for context in required_contexts(doc)}
     assert "advisory / prek-advisory" in composed - required
+    assert "guard / dependency-review" in composed - required

--- a/tests/test_workflow_properties.py
+++ b/tests/test_workflow_properties.py
@@ -1,5 +1,7 @@
 import re
+import tomllib
 from itertools import pairwise
+from typing import cast
 
 from capabilities import (
     CONVENTIONAL_COMMITS,
@@ -7,6 +9,7 @@ from capabilities import (
     WORKFLOW_DIR,
     Doc,
     action_paths,
+    declared_input_specs,
     declared_inputs,
     fixture,
     is_capability,
@@ -100,6 +103,148 @@ def test_the_permission_reader_tells_an_explained_grant_from_a_bare_one() -> Non
 
 def steps_of(name: str, job_id: str) -> list[Doc]:
     return list(jobs(load(WORKFLOW_DIR / f"{name}.yml"))[job_id]["steps"])
+
+
+def uses_slugs(steps: list[Doc]) -> set[str]:
+    # The slug is the part before `@`. The digest is deliberately not read here: the workflow owns
+    # the pin and test_action_pins.py owns whether it is a full SHA, so a bump stays a one-file edit.
+    return {str(step["uses"]).partition("@")[0] for step in steps if "uses" in step}
+
+
+def test_dependency_review_uses_only_the_pinned_action() -> None:
+    # FR-002, FR-015: no checkout and no task-runner step. The action reads the difference from the
+    # API, so a checkout beside it would be this capability reading a tree it has no reason to have.
+    slugs = uses_slugs(steps_of("dependency-review", "dependency-review"))
+    assert slugs == {"actions/dependency-review-action"}, (
+        f"dependency-review's job uses {sorted(slugs)}, expected exactly "
+        "{'actions/dependency-review-action'}. A checkout or a task-runner step here is what "
+        "FR-002/FR-015 forbid"
+    )
+
+
+def test_the_uses_slug_reader_refuses_a_checkout_beside_the_real_step() -> None:
+    # Pre-flight the reader (FR-022): its steady state is a one-element set, so a change that stopped
+    # it finding anything would report green over a capability that checks the caller's tree out.
+    slugs = uses_slugs(
+        [
+            {"uses": "actions/checkout@abc123"},
+            {"uses": "actions/dependency-review-action@a1d282b"},
+        ]
+    )
+    assert slugs == {"actions/checkout", "actions/dependency-review-action"}
+
+
+# The one key this capability passes the action. Every other key the action declares — the pull
+# request comment, a licence list, an override — stays unset, so the action's defaults are the policy.
+ALLOWED_REVIEW_INPUT = "fail-on-severity"
+
+
+def review_with_keys() -> set[str]:
+    step = next(
+        step
+        for step in steps_of("dependency-review", "dependency-review")
+        if step.get("id") == "review"
+    )
+    return {str(key) for key in cast(Doc, step.get("with") or {})}
+
+
+def test_dependency_review_passes_the_action_only_its_one_input() -> None:
+    keys = review_with_keys()
+    assert keys == {ALLOWED_REVIEW_INPUT}, (
+        f"dependency-review's review step passes {sorted(keys)}, the one key this capability allows "
+        f"is {ALLOWED_REVIEW_INPUT!r}. comment-summary-in-pr at always or on-failure demands "
+        "pull-requests: write, which every caller would then have to grant before any job exists"
+    )
+
+
+def test_the_with_key_check_would_catch_an_extra_key() -> None:
+    # Pre-flight the same logic on a synthetic `with:` block, proving the gate above would catch it.
+    keys = {str(key) for key in {"fail-on-severity": "low", "comment-summary-in-pr": "always"}}
+    assert keys != {ALLOWED_REVIEW_INPUT}
+
+
+def test_every_published_workflow_input_documents_itself() -> None:
+    # FR-004. An input whose behaviour when unset is unwritten is a promise with nothing behind it.
+    committed = fixture()
+    missing: list[str] = []
+    for name, doc in workflow_docs().items():
+        row = committed.get(name, {})
+        if not (row.get("kind") == "workflow" and row.get("published")):
+            continue
+        for input_name, spec in declared_input_specs(doc).items():
+            if not str(spec.get("description", "")).strip():
+                missing.append(f"{name}: input {input_name!r} has no description")
+            if "default" not in spec:
+                missing.append(f"{name}: input {input_name!r} has no default")
+    assert missing == [], "; ".join(missing)
+
+
+def test_the_input_spec_check_would_catch_a_missing_description() -> None:
+    # Pre-flight on a synthetic input spec, or a change that stopped this reading anything reports
+    # green over a published input nobody documented.
+    spec: Doc = {"type": "string", "default": "low"}
+    assert not str(spec.get("description", "")).strip()
+
+
+def find_graph_off_step(steps: list[Doc]) -> Doc | None:
+    # Found by id, never by retyping the condition — a reworded condition would then match nothing
+    # and this would report green over a missing diagnostic.
+    matches = [step for step in steps if step.get("id") == "graph-off"]
+    assert len(matches) <= 1, f"more than one step id 'graph-off': {matches}"
+    return matches[0] if matches else None
+
+
+def test_dependency_review_names_the_setting_it_cannot_switch_on() -> None:
+    # FR-011, FR-024.
+    step = find_graph_off_step(steps_of("dependency-review", "dependency-review"))
+    assert step is not None, (
+        "dependency-review names no step id 'graph-off'. Add one, gated on `failure() && "
+        "steps.review.outputs.dependency-changes == ''`, whose run: names the dependency-graph "
+        "setting and says this capability cannot switch it on for the caller"
+    )
+    condition = str(step.get("if", ""))
+    assert "failure()" in condition, (
+        f"graph-off runs under `if: {condition}`, which does not check failure() — it could fire on a "
+        "run that judged a real advisory"
+    )
+    assert "steps.review.outputs.dependency-changes" in condition, (
+        f"graph-off runs under `if: {condition}`, which does not read dependency-changes, the "
+        "discriminator between a run that read the comparison and one that judged nothing"
+    )
+    script = str(step.get("run", ""))
+    assert "security_analysis" in script, (
+        f"graph-off's run: {script!r} does not name the dependency-graph setting"
+    )
+    assert "cannot" in script.lower(), (
+        f"graph-off's run: {script!r} does not say this capability cannot switch the setting on"
+    )
+
+
+def test_the_graph_off_finder_reports_the_absence_rather_than_passing() -> None:
+    # Pre-flight the finder with a synthetic step list carrying no `graph-off` id.
+    assert find_graph_off_step([{"id": "review"}]) is None
+
+
+def test_the_release_exclude_list_names_exactly_the_non_capability_workflows() -> None:
+    # FR-018. Read at release time and nowhere else, so a caller missing here has no symptom until it
+    # skews a version decision — the failure mode is silence, which is why this is a gate.
+    config = tomllib.loads((REPO / "pyproject.toml").read_text(encoding="utf-8"))
+    excluded = {
+        str(entry)
+        for entry in config["tool"]["turbobasic-release"]["exclude"]
+        if str(entry).startswith(".github/workflows/")
+    }
+    callers = {
+        f".github/workflows/{name}.yml"
+        for name, doc in workflow_docs().items()
+        if not is_capability(doc)
+    }
+    assert excluded == callers, (
+        f"[tool.turbobasic-release].exclude names {sorted(excluded)} under .github/workflows/; the "
+        f"workflows that are not capabilities are {sorted(callers)}. A caller missing from exclude "
+        "makes a later edit to this repository's own call site count towards a break; an entry naming "
+        "a workflow that has since become a capability is stale"
+    )
 
 
 def test_no_capability_takes_an_input_governing_the_cache() -> None:

--- a/tests/test_workflow_properties.py
+++ b/tests/test_workflow_properties.py
@@ -139,17 +139,13 @@ def test_the_uses_slug_reader_refuses_a_checkout_beside_the_real_step() -> None:
 ALLOWED_REVIEW_INPUT = "fail-on-severity"
 
 
-def review_with_keys() -> set[str]:
-    step = next(
-        step
-        for step in steps_of("dependency-review", "dependency-review")
-        if step.get("id") == "review"
-    )
+def review_with_keys(steps: list[Doc]) -> set[str]:
+    step = next(step for step in steps if step.get("id") == "review")
     return {str(key) for key in cast(Doc, step.get("with") or {})}
 
 
 def test_dependency_review_passes_the_action_only_its_one_input() -> None:
-    keys = review_with_keys()
+    keys = review_with_keys(steps_of("dependency-review", "dependency-review"))
     assert keys == {ALLOWED_REVIEW_INPUT}, (
         f"dependency-review's review step passes {sorted(keys)}, the one key this capability allows "
         f"is {ALLOWED_REVIEW_INPUT!r}. comment-summary-in-pr at always or on-failure demands "
@@ -157,33 +153,55 @@ def test_dependency_review_passes_the_action_only_its_one_input() -> None:
     )
 
 
-def test_the_with_key_check_would_catch_an_extra_key() -> None:
-    # Pre-flight the same logic on a synthetic `with:` block, proving the gate above would catch it.
-    keys = {str(key) for key in {"fail-on-severity": "low", "comment-summary-in-pr": "always"}}
-    assert keys != {ALLOWED_REVIEW_INPUT}
+def test_the_with_key_reader_finds_the_extra_key_beside_the_allowed_one() -> None:
+    # Pre-flight the reader. Its steady state is a one-element set, so a reader that stopped finding
+    # the `with:` block would report green over a capability demanding pull-requests: write.
+    keys = review_with_keys(
+        [{"id": "review", "with": {"fail-on-severity": "low", "comment-summary-in-pr": "always"}}]
+    )
+    assert keys == {ALLOWED_REVIEW_INPUT, "comment-summary-in-pr"}
+
+
+def undocumented_inputs(name: str, specs: dict[str, Doc]) -> list[str]:
+    complaints: list[str] = []
+    for input_name, spec in specs.items():
+        if not str(spec.get("description", "")).strip():
+            complaints.append(f"{name}: input {input_name!r} has no description")
+        if "default" not in spec:
+            complaints.append(f"{name}: input {input_name!r} has no default")
+    return complaints
 
 
 def test_every_published_workflow_input_documents_itself() -> None:
-    # FR-004. An input whose behaviour when unset is unwritten is a promise with nothing behind it.
+    # FR-004.
     committed = fixture()
     missing: list[str] = []
     for name, doc in workflow_docs().items():
         row = committed.get(name, {})
         if not (row.get("kind") == "workflow" and row.get("published")):
             continue
-        for input_name, spec in declared_input_specs(doc).items():
-            if not str(spec.get("description", "")).strip():
-                missing.append(f"{name}: input {input_name!r} has no description")
-            if "default" not in spec:
-                missing.append(f"{name}: input {input_name!r} has no default")
-    assert missing == [], "; ".join(missing)
+        missing += undocumented_inputs(name, declared_input_specs(doc))
+    assert missing == [], (
+        "; ".join(missing) + ". An input whose behaviour when unset is unwritten is a promise with "
+        "nothing behind it: give it a description and an explicit default in the workflow that "
+        "declares it"
+    )
 
 
-def test_the_input_spec_check_would_catch_a_missing_description() -> None:
-    # Pre-flight on a synthetic input spec, or a change that stopped this reading anything reports
-    # green over a published input nobody documented.
-    spec: Doc = {"type": "string", "default": "low"}
-    assert not str(spec.get("description", "")).strip()
+def test_the_input_spec_check_names_the_key_each_input_is_missing() -> None:
+    # Pre-flight the check. Its steady state is an empty list, so a check that stopped reading a spec
+    # would report green over a published input nobody documented.
+    complaints = undocumented_inputs(
+        "synthetic",
+        {
+            "no-description": {"type": "string", "default": "low"},
+            "no-default": {"type": "string", "description": "the floor a finding fails at"},
+        },
+    )
+    assert complaints == [
+        "synthetic: input 'no-description' has no description",
+        "synthetic: input 'no-default' has no default",
+    ]
 
 
 def find_graph_off_step(steps: list[Doc]) -> Doc | None:
@@ -225,6 +243,12 @@ def test_the_graph_off_finder_reports_the_absence_rather_than_passing() -> None:
     assert find_graph_off_step([{"id": "review"}]) is None
 
 
+def exclude_disagreement(excluded: set[str], callers: set[str]) -> tuple[set[str], set[str]]:
+    # The two directions separately: callers no exclude entry names, then entries naming a workflow
+    # that is a capability now. A bare `==` would name neither in the failure.
+    return callers - excluded, excluded - callers
+
+
 def test_the_release_exclude_list_names_exactly_the_non_capability_workflows() -> None:
     # FR-018. Read at release time and nowhere else, so a caller missing here has no symptom until it
     # skews a version decision — the failure mode is silence, which is why this is a gate.
@@ -239,12 +263,29 @@ def test_the_release_exclude_list_names_exactly_the_non_capability_workflows() -
         for name, doc in workflow_docs().items()
         if not is_capability(doc)
     }
-    assert excluded == callers, (
-        f"[tool.turbobasic-release].exclude names {sorted(excluded)} under .github/workflows/; the "
-        f"workflows that are not capabilities are {sorted(callers)}. A caller missing from exclude "
-        "makes a later edit to this repository's own call site count towards a break; an entry naming "
-        "a workflow that has since become a capability is stale"
+    # Two empty sets agree, which is the one state this gate passes without reading the tree.
+    assert callers, (
+        "no workflow in the tree reads as a caller, so the comparison below would agree over nothing. "
+        "is_capability or workflow_docs has stopped reading the tree — fix the reader, not this gate"
     )
+    unlisted, stale = exclude_disagreement(excluded, callers)
+    assert not unlisted and not stale, (
+        f"[tool.turbobasic-release].exclude does not name {sorted(unlisted)}, and names "
+        f"{sorted(stale)} which are capabilities. A caller missing from exclude makes a later edit to "
+        "this repository's own call site count towards a break; an entry naming a workflow that has "
+        "since become a capability keeps consumer surface out of the range a release reads"
+    )
+
+
+def test_the_exclude_comparison_names_both_directions_it_claims_to_catch() -> None:
+    # Pre-flight the comparison. Set equality alone would report a disagreement without saying which
+    # side, and the gate's message promises both.
+    unlisted, stale = exclude_disagreement(
+        {".github/workflows/ci.yml", ".github/workflows/release.yml"},
+        {".github/workflows/ci.yml", ".github/workflows/advisory.yml"},
+    )
+    assert unlisted == {".github/workflows/advisory.yml"}
+    assert stale == {".github/workflows/release.yml"}
 
 
 def test_no_capability_takes_an_input_governing_the_cache() -> None:


### PR DESCRIPTION
## What changed

- feat: add one check over what a change starts depending on

## Why?

Every capability this library publishes today judges the code in a change; none judges what
the change starts depending on. A pull request adding a package with a known advisory is green
on every existing check, because none of them read the dependency-graph difference. This adds a
sixth capability, `dependency-review`, that reads that difference through GitHub's own pinned
action and reddens on an advisory at or above a severity floor — and makes this repository a
real consumer of it via `dependency-guard.yml`, without requiring the composed context.

## Blast radius

Consumers: none — this only adds surface (a new capability, no existing input, default or
permission moves). This repository: `guard / dependency-review` now reports on every pull
request here and is deliberately not required in the branch ruleset.

## Verification

`mise run ci` (lint, typecheck, test — 158 tests) passes offline. Hand-worked all 8 rows of
`specs/004-dependency-review/quickstart.md`'s "prove each gate can fail" table: each planted
violation reddens the right gate with a message naming what to fix, then reverted clean.

The "Online" half of quickstart.md — a real pull request against a repository with a known
advisory, and one with the dependency graph switched off — needs network access and a live
repository, so it is not run here. Worth doing once this is up for review.

## Docs

`README.md` gains a `### dependency-review` section; `specs/004-dependency-review/spec.md`'s
status is marked implemented.

## Commits

- feat: add one check over what a change starts depending on

  A sixth published capability, dependency-review, reads the dependency-graph
  difference between a pull request's base and its head through the pinned
  actions/dependency-review-action and reddens on an advisory at or above a
  severity floor. It is the only capability here judging what a change starts
  depending on rather than what it says.

  dependency-guard.yml makes this repository a real consumer of its own
  capability, at the commit under review, without requiring the composed
  context in the branch ruleset.
