### PR TITLE
docs: merge instruction layers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Four layers, the most abstract first.
 | --- | --- | --- | --- | --- |
 | 1 | Invariants | what may never be violated | amended and versioned, rarely | `.specify/memory/constitution.md` |
 | 2 | Conventions | how work is done here | edited as practice settles | `docs/ai-instructions.md` |
-| 3 | Mechanics | the procedures and the gates | moves with the code | `README.md`, `docs/technical-debt.md`, `tests/`, and the configs below |
+| 3 | Mechanics | the procedures and the gates | moves with the code | `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `docs/technical-debt.md`, `tests/`, and the configs below |
 | 4 | Navigation | where each fact lives | moves when an artefact does | this file, `CLAUDE.md`, `.github/copilot-instructions.md` |
 
 How each tool reaches the rule layers differs, and layer 4 is where that difference is absorbed.
@@ -31,6 +31,9 @@ and reaches the rule layers by link. Layer 3 is read on demand by both.
 | Artefact | Answers |
 | --- | --- |
 | `README.md` | what this repository is for, and what it currently ships |
+| `CONTRIBUTING.md` | the setup, the loop, how a workflow change is verified, the label set, and how a release is cut |
+| `SECURITY.md` | how something exploitable is reported, and what counts as in scope |
+| `CODE_OF_CONDUCT.md` | what taking part requires |
 | `docs/technical-debt.md` | which shortcuts are deliberate, and the condition that clears each |
 | `docs/instruction-layers.md` | the layering itself, explained for another repository to adopt |
 | `tests/` | every rule a gate holds |

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,71 @@
+# Code of Conduct
+
+## The short version
+
+Be decent. Assume good faith. Own your mistakes.
+
+This is a small repository about reusable CI. Most friction here will be a misread tone in a review
+comment, not malice — say so plainly and move on. This document is for the rest.
+
+It applies in every space this project uses — issues, pull requests, discussions, commit messages —
+and to anyone representing the project elsewhere.
+
+## What we expect
+
+- Engage with the argument, not the person making it.
+- Take the feedback. Reviews are about the diff; a rejected change is not a rejected person.
+- Say "my bad" when you get it wrong, then fix it. That is the whole apology ritual.
+- Respect a stated boundary the first time.
+- Credit what you did not write — code, prose, or an idea from someone else's issue.
+
+Everyone participating in good faith gets the same standing here, whatever their race, ethnicity,
+caste, colour, age, physical characteristics, neurodiversity, disability, sex or gender, gender
+identity or expression, sexual orientation, language, religion or philosophy, national or social
+origin, class, or level of education. Beginners included: nobody is unwelcome for not knowing
+something yet.
+
+## Not okay
+
+- **Harassment** — continuing unwanted attention after a clear request to stop.
+- **Personal attacks** — insults, demeaning remarks, contempt aimed at a person or group.
+- **Discrimination** — slurs, stereotyping, or judging someone by an identity rather than their work.
+- **Sexualisation** — sexual attention or comments; entirely out of place in a code review.
+- **Breaking confidence** — publishing or acting on someone's private information.
+- **Threats** — encouraging or threatening harm to anyone.
+- **Impersonation** — posing as someone else, including to get around an enforcement action.
+- **Plagiarism** — presenting someone else's work as your own.
+
+Doing these to someone who "started it" is still doing these.
+
+## Reporting
+
+Report privately through GitHub: **Report content** on the offending comment, issue, or profile
+(`···` menu → *Report content*), or contact [@turboBasic](https://github.com/turboBasic) directly.
+
+Reports are handled in private. You will not be asked to confront the other person, and you will not
+be told to just work it out. Not every conflict is a violation, and saying so is a legitimate
+outcome — but it is a judgement made after looking, not a way to avoid looking.
+
+## What happens next
+
+Responses aim at repairing the harm, and escalate only as far as they have to:
+
+1. **A word in private** — for a one-off. Usually ends in an apology and a clarified expectation.
+2. **A cooling-off period** — time-boxed, possibly limited to one thread. For a repeat after a
+   warning, or a first offence that was serious.
+3. **Temporary suspension** — with stated conditions for coming back. For a pattern that warnings
+   did not shift.
+4. **Permanent ban** — for a pattern nothing else resolved, or a single violation severe enough that
+   there is no safe way to keep someone here.
+
+Steps get skipped when severity warrants it. As maintainer I make the call, and I will explain the
+reasoning to the people involved.
+
+## Attribution
+
+Adapted from [Contributor Covenant 3.0](https://www.contributor-covenant.org/version/3/0/),
+stewarded by the Organization for Ethical Source and licensed
+[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). Rewritten for length and tone; the
+enforcement ladder is theirs, itself inspired by
+[Mozilla's](https://github.com/mozilla/inclusion). This adaptation is offered under the same
+licence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,203 @@
+# Contributing
+
+This repository holds the CI that other `turboBasic` repositories run. A change to a capability reaches
+every consumer pinned to the moving ref on their next push, so the question a change answers is whether
+a caller on that ref can absorb it — see [Versioning][readme-versioning].
+Forking to suit your own conventions is an expected use; the [MIT licence][license] asks nothing beyond
+keeping the notice.
+
+Taking part means following the [Code of Conduct][coc]. Report anything exploitable privately instead of
+opening an issue — see the [security policy][security].
+
+## Read this first
+
+Two files carry the rules and bind humans and AI tools alike: [the constitution][constitution] states
+what may never be violated, and [`docs/ai-instructions.md`][ai-instructions] states how work is done
+here. This file repeats neither.
+
+Start with [Changes to these rules][ai-instructions-changes]: it says how the conventions relate to the
+layers around them, and everything in that file is one. The constitution's Governance section owns what
+a request to erode an invariant obliges. The rest covers
+[tooling][ai-instructions-tooling],
+[capabilities][ai-instructions-capabilities],
+[quality gates][ai-instructions-quality], and
+[versioning][ai-instructions-versioning].
+
+## Setup
+
+```sh
+mise run setup
+```
+
+One command; it wires up the `pre-commit` and `commit-msg` hooks together.
+
+## The loop
+
+```sh
+mise run ci      # lint, schema validation, typecheck, test — exactly what CI runs
+```
+
+## Specs
+
+Which changes need a spec first, and the sequence one goes through, is settled in
+[ai-instructions][ai-instructions-specs]; the gates a spec is read against are in
+[the constitution][constitution].
+
+A spec lands in `specs/NNN-slug/` on your branch and merges with the code it describes. Until that merge
+it is a proposal — the PR review is what makes it an artifact, so put it up for review before building
+against it.
+
+## Verifying a workflow change
+
+Lint is necessary and not sufficient. **Run every workflow you change.** YAML that parses still fails on
+a missing input, a permission nobody granted, an expression that picks the wrong branch, or a CLI that
+wants a context the runner lacks.
+
+Every capability is called by this repository itself, so opening a pull request here exercises each one
+at the commit under review. That covers the code and not the caller: what turns on caller-side
+configuration — `python-ci`'s `hook-stage` and its stage switches, a consumer with no `mise.toml` — is
+only exercised by a real consumer at the ref it pins.
+
+Before a change to a capability is done:
+
+1. Push the branch and open a PR here, so this repository's own CI runs.
+2. Open a branch in [`github-actions-test`][test-consumer], point its call site at `@<your-branch>`, and
+   exercise both outcomes — the passing path and the failing one. A check that cannot fail is not a
+   check.
+3. Leave that branch. Nothing there needs deleting, and a scenario worth running once is worth keeping:
+   `tests/scenario-*/README.md` says what each existing branch covers and what it asserts in the log, so
+   start from the nearest one.
+
+Move the compatibility ref only after that.
+
+A workflow no consumer calls — `ci.yml`, `commit-messages.yml`, `describe-pr.yml`, `advisory.yml`,
+`dependency-guard.yml`, `release-on-merge.yml`, `release-proposal.yml`, `apply-ruleset.yml` — has no
+caller but this repository. Dispatch it, or open a PR that triggers it, and read the run. `release.yml`
+has no trigger of its own: dispatch `release-on-merge.yml` to reach it. A brand-new workflow cannot be
+dispatched at all — GitHub offers `workflow_dispatch` only for a workflow file already on the default
+branch — so exercising one before merge means a temporary trigger scoped to your branch, removed in the
+same pull request.
+
+## Labels
+
+Labels are on **issues only**, and nothing automated reads them — release notes come from commit types
+via `cliff.toml`. A PR's kind already lives in its Conventional Commit title, so labelling one would be a
+second source of truth about what kind of change it is.
+
+Two required axes and three flags:
+
+| Axis | Labels | Rule |
+| --- | --- | --- |
+| kind | `kind:bug` `kind:feat` `kind:chore` `kind:docs` | exactly one |
+| area | `area:workflows` `area:actions` `area:release` `area:tooling` | one or more |
+| flags | `breaking` `blocked` `needs-spec` | as they apply |
+
+**This table is the label set.** Adding a label means adding it here and running `gh label create`.
+Nothing asserts it against the live repository: which paths are consumer-facing is already declared as
+`[tool.turbobasic-release]` in `pyproject.toml`, and that declaration is what the release is judged
+against — a label is a filing aid, not an input to anything.
+
+Colour is by axis, not by label — `kind:` blue, `area:` purple, a flag red or amber. Darkest first down
+each axis. Nothing asserts a colour: it carries no data anyone groups by, and a rule regenerates it
+without a table of hex codes to keep current.
+
+`breaking` means shipping it needs a new compatibility line rather than a move of the current ref — which
+line that is depends on where the version stands, so a breaking issue waits for the milestone that cuts
+it rather than naming one here.
+
+Do not label a closure. GitHub's own close reason — *not planned*, *duplicate* — already records it and
+is queryable.
+
+```sh
+gh issue list --state open --json labels --jq '[.[].labels[].name]|group_by(.)|map({(.[0]):length})'
+```
+
+## Pull requests
+
+Branch first. Title the PR as a Conventional Commit — a squash merge takes its subject from there. Every
+required check must pass; which ones those are is committed in `.github/rulesets/`.
+
+Say whether a caller on the current ref can absorb the change and what you ran to verify it, and update
+the [README][readme] in the same change when a capability's shape moves. Agent-written code is welcome;
+you are still the author of it.
+
+## Releasing
+
+Merging changes nothing for consumers. They pin the moving ref — see [Versioning][readme-versioning] —
+and it only moves when a release is cut, which is **one step: approve a proposal.**
+
+After any merge to `main` that leaves something worth describing, the [Release
+proposal][release-proposal-workflow] workflow opens a pull request titled `chore: release vX.Y.Z`. Its
+body is the exact notes that release will publish, and its diff is `pyproject.toml`'s `[project].version`
+and `uv.lock`'s matching line, nothing else. Read the notes, and:
+
+- **Agree with the version?** Merge it. [Release on merge][release-workflow] runs on the merge commit
+  and, once its `verify` job passes, cuts the release. No further human action. `ci.yml` runs on the same
+  commit and answers for the code alone, so a refused or failed release never reddens it.
+- **Disagree with the version?** Change it on the proposal branch before merging. The released version is
+  the one you approved, and every later refresh leaves it alone — a commit on that branch authored by
+  anyone but the bot is how the workflow knows a human has decided.
+
+The proposal proposes; it does not decide. `pyproject.toml` is the only place the version is decided, and
+what the number describes is [ai-instructions][ai-instructions-versioning]'s rule: the consumer-facing
+surface, declared as `[tool.turbobasic-release]` in that same file.
+
+What the release refuses, and what it does on a merge that releases nothing, is the
+[README][readme-release]'s: it is the same capability a consumer calls. Two things are ours alone:
+
+- [Dispatching Release on merge][release-workflow] with `dry-run` runs every refusal and renders the real
+  notes on a runner, creating nothing — on a commit that is already tagged it stops at the empty-range
+  refusal, which is that refusal working. It is the only safe way to exercise the release path.
+- If a release fails *after* the version tag exists, recover by merging the next patch version. That tag
+  cannot be deleted, and the compatibility ref moves last precisely so consumers stay on the previous
+  release until the rest has succeeded.
+
+### Repinning consumers onto a new line
+
+Only a break needs this; nothing else asks a consumer to act. Repin
+[`github-actions-test`][test-consumer] first — it is the one caller whose configuration is not ours, so a
+rename is unverified for a consumer until that repository is green.
+
+Then, per consumer, two orderings that are not interchangeable. Its ruleset flips **after** its repin
+branch has reported the new check names, never before — a required context that has never reported blocks
+every open pull request in that repository, not just the one doing the repin. And between the flip and the
+merge, that repository's `main` still resolves the old ref, so any *other* pull request opened in that
+window reports the retired names and blocks. Keep the window short, and expect a consumer whose ruleset
+requires an approving review not to merge unattended.
+
+### The App behind the proposal
+
+The proposal is opened by a GitHub App, `turbobasic-release-proposal`, installed on this repository with
+`Contents` and `Pull requests` write and nothing else. Its client id and private key live in the
+`RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY` Actions secrets, and the token each run mints is
+narrowed to those two permissions and expires in an hour.
+
+`GITHUB_TOKEN` cannot do this job: opening a pull request from Actions requires *Allow GitHub Actions to
+create and approve pull requests*, which is off here and stays off, because it grants approving as well as
+opening. An App is not "GitHub Actions", so it is not subject to that setting — and its pull requests
+trigger the required checks with no click.
+
+**If that key is rotated or the installation removed, no proposal is raised and nothing says so.** No
+check reddens, because nothing failed: the workflow simply cannot mint a token. Reach for a dispatch of
+[Release on merge][release-workflow] with `dry-run` to confirm the release path still works, and re-add the
+secrets before expecting another proposal.
+
+<!-- Links -->
+
+[license]: LICENSE
+[coc]: CODE_OF_CONDUCT.md
+[security]: SECURITY.md
+[ai-instructions]: docs/ai-instructions.md
+[ai-instructions-changes]: docs/ai-instructions.md#changes-to-these-rules
+[ai-instructions-specs]: docs/ai-instructions.md#specs
+[constitution]: .specify/memory/constitution.md
+[ai-instructions-tooling]: docs/ai-instructions.md#tooling-hierarchy
+[ai-instructions-capabilities]: docs/ai-instructions.md#capabilities
+[ai-instructions-quality]: docs/ai-instructions.md#quality-gates
+[ai-instructions-versioning]: docs/ai-instructions.md#versioning
+[readme]: README.md
+[test-consumer]: https://github.com/turboBasic/github-actions-test
+[readme-versioning]: README.md#versioning
+[readme-release]: README.md#release
+[release-proposal-workflow]: https://github.com/turboBasic/github-actions-new/actions/workflows/release-proposal.yml
+[release-workflow]: https://github.com/turboBasic/github-actions-new/actions/workflows/release-on-merge.yml

--- a/README.md
+++ b/README.md
@@ -359,7 +359,5 @@ its own code, and there is nothing for you to bootstrap.
 
 `AGENTS.md` is the map — it names every artefact and what that artefact answers. Start there.
 
-```console
-mise run setup   # tools, dependencies, git hooks
-mise run ci      # everything CI runs
-```
+`CONTRIBUTING.md` has the setup, the loop, how a change to a capability is verified, and how a release is
+cut. Anything exploitable goes to `SECURITY.md`'s private report rather than an issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security policy
+
+## What this repository is
+
+The CI that other `turboBasic` repositories run. It ships no service and is published to no package
+index, but it is the highest-leverage repository in the account: code here executes in every repository
+that pins it, and it runs holding whatever token the caller's job grants.
+
+In scope, roughly in order of how much it matters:
+
+- **Anything that lets an untrusted pull request execute code or reach a token.** A `${{ }}`
+  interpolation of a pull request title or a branch name into a `run:` line, a workflow triggered on
+  `pull_request_target`, a token passed to a step that did not need it. Constitution principle VI gives
+  the reason, and `tests/test_no_interpolation.py` holds it.
+- **A supply-chain regression in a pinned action.** Every third-party action here is pinned to a full
+  commit SHA. CVE-2025-30066 is the reason realised: a repointed tag on `tj-actions/changed-files` leaked
+  secrets into build logs. A floating ref reaching `main` is a vulnerability, not a style lapse, and
+  `tests/test_action_pins.py` exists to stop it.
+- **A capability that demands more permission than it needs.** Permissions only reduce down a call chain,
+  so a caller cannot constrain a reusable workflow that asks for too much, and reverting the code here
+  does not un-grant what a consumer already granted. What each capability demands is frozen in
+  `tests/published_surface.toml`.
+
+There are no supported versions to list beyond the moving compatibility ref, which moves. If you pinned an
+exact release tag, you own that copy.
+
+## Reporting
+
+Use [private vulnerability reporting](https://github.com/turboBasic/github-actions-new/security/advisories/new).
+It keeps the report unpublished while it is being looked at.
+
+Do not open a public issue for something exploitable. For a workflow you think is merely ill-advised, a
+public issue is the right place — that is a design argument, not a disclosure.
+
+Expect a reply within a week. This is a personal project, not a staffed product; if that is too slow for
+what you found, say so in the report and disclose on your own timeline.
+
+## Secrets
+
+No secret belongs in this repository, in any form, including a test fixture (constitution principle II).
+The capabilities here read `secrets.GITHUB_TOKEN` at the call site or mint a narrowed App token in the step
+that uses it; none stores one.
+
+If you find a live credential committed anywhere in this repository's history, report it privately. Push
+protection and secret scanning are on, so a recognised token format is blocked at push time. Neither
+catches everything.

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -21,7 +21,10 @@ assuming, extend it, and never regenerate it. The entry point names which file h
 
 A user-level instruction file is concatenated into context ahead of this one with no override
 mechanism, so a contradiction between the two has nowhere else to be resolved. **This repository's
-rules win where they are stricter.**
+rules win where they are stricter.** Two are live today. A user-level file that permits a third-party
+action pinned to a tag rather than a full commit SHA does not permit one here, and one that permits
+`@main` for an in-house reference does not permit it here — nothing of this repository's own names a ref
+at all.
 
 ### Changes to these rules
 
@@ -115,6 +118,8 @@ restores the world.
   consumer does not control — that agreement is the only reason a local verdict and a CI verdict match.
 - **An input named for a stage governs that stage entirely.** If it leaves some part of the stage
   running, it is misnamed.
+- **`env` does not propagate from a caller into a called workflow.** Anything a capability needs from
+  its caller arrives as an `input`.
 
 ### Python
 
@@ -125,6 +130,13 @@ Python 3.14. The only Python here supports the actions and their tests.
 - Full type hints on every signature, tests included.
 - A script invoked by a composite action reads its arguments from the environment, declared in
   `action.yml`. It never parses `${{ }}` interpolations inline.
+- **A module a composite action runs imports the standard library and nothing else, and keeps to syntax
+  an older interpreter parses.** mise pins 3.14 here, but a caller whose own configuration pins no
+  `python` falls back to the runner's, and `python3` is what runs the file — there is no resolution step
+  to fail loudly. Its imports are asserted against `sys.stdlib_module_names` by test.
+- **A module a composite action runs is importable by the suite and by the type checker.** A hyphen in
+  the directory it sits in means neither can reach it as a package, so the suite's own path setup and
+  pyright's `extraPaths` each name that directory. Both are needed; neither is a relaxation.
 
 ### Comments and docs
 
@@ -149,6 +161,10 @@ Python 3.14. The only Python here supports the actions and their tests.
   repointed.
 - **Pre-flight the line out of the file, never a retyping of it**, or you test your typing rather than
   the file.
+- **This repository stays public, or every consumer needs an access policy.** A private caller resolves
+  these capabilities only because this one is public; make it private and each consumer has to allow
+  access to repositories this owner holds before anything of theirs resolves again. Asserting it would
+  need the network, so it is stated here and held nowhere.
 
 ## Shipping
 

--- a/tests/test_action_imports.py
+++ b/tests/test_action_imports.py
@@ -1,0 +1,44 @@
+import ast
+import sys
+from pathlib import Path
+
+ACTIONS = Path(__file__).parent.parent / "actions"
+
+
+def imported_roots(source: str) -> set[str]:
+    roots: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            roots |= {alias.name.split(".")[0] for alias in node.names}
+        # A relative import resolves against a package, and a hyphen in the directory beside the action
+        # means there is none. It is reported as `.`, which no standard-library name matches.
+        if isinstance(node, ast.ImportFrom):
+            roots.add(node.module.split(".")[0] if node.level == 0 and node.module else ".")
+    return roots
+
+
+def test_every_module_a_composite_action_runs_imports_only_the_standard_library() -> None:
+    modules = sorted(ACTIONS.glob("*/*.py"))
+    assert modules, "no action module was read, so this gate holds no import at all"
+    foreign = [
+        f"{module.parent.name}/{module.name} imports {name}"
+        for module in modules
+        for name in sorted(imported_roots(module.read_text(encoding="utf-8")))
+        if name not in sys.stdlib_module_names
+    ]
+    assert foreign == [], (
+        f"an action module imports outside the standard library: {foreign}. Nothing installs a "
+        "dependency before the module runs, and the interpreter is whichever `python3` the caller's own "
+        "configuration left on the runner — so there is no resolution step to fail loudly here, only an "
+        "ImportError in a consumer's job. Move the work to the suite, or into the action's own steps"
+    )
+
+
+def test_the_import_walk_reads_the_forms_it_is_given() -> None:
+    # Pre-flight the walk, or a change that stops it finding imports reports green over a module
+    # importing whatever it likes.
+    assert imported_roots("import os\nimport a.b.c\n") == {"os", "a"}
+    assert imported_roots("from collections.abc import Iterable\n") == {"collections"}
+    assert imported_roots("def f() -> None:\n    import yaml\n") == {"yaml"}
+    assert imported_roots("from . import sibling\n") == {"."}
+    assert "." not in sys.stdlib_module_names

--- a/tests/test_instruction_layers.py
+++ b/tests/test_instruction_layers.py
@@ -11,6 +11,9 @@ LAYERS: dict[int, frozenset[str]] = {
     3: frozenset(
         {
             "README.md",
+            "CONTRIBUTING.md",
+            "SECURITY.md",
+            "CODE_OF_CONDUCT.md",
             "docs/instruction-layers.md",
             "docs/technical-debt.md",
             ".github/PULL_REQUEST_TEMPLATE.md",

--- a/tests/test_repo_urls.py
+++ b/tests/test_repo_urls.py
@@ -17,6 +17,16 @@ EXEMPT: dict[str, str] = {
     "README.md": "states the staging arrangement, so it names the destination and the staging repo",
 }
 
+# Another repository of this owner's, named on purpose. The matcher cannot tell a stale self URL from a
+# deliberate reference to a different repository, so each deliberate one is named here with why —
+# exempting the file instead would stop checking that file's own self URLs, which is what the gate is for.
+OTHER_REPOSITORIES: dict[str, str] = {
+    "turboBasic/github-actions-test": (
+        "the verification harness; a capability's caller-side behaviour is exercised from there, and it "
+        "is deliberately not this repository"
+    ),
+}
+
 
 # A `uses:` slug is a resolvable reference just like a URL, and GitHub redirects a renamed
 # repository's refs too — so a stale one keeps working and nothing announces the drift. The README is
@@ -58,12 +68,20 @@ def test_every_self_url_names_the_repository_this_clone_actually_is() -> None:
         if path.startswith((".specify/", ".claude/skills/speckit-")):
             continue
         text = (REPO / path).read_text(encoding="utf-8", errors="ignore")
-        stale += [f"{path}: {m}" for m in URL_OWNER_REPO.findall(text) if m != slug]
-    assert stale == [], f"URL names a repository other than {slug}: {stale}"
+        stale += [
+            f"{path}: {m}"
+            for m in URL_OWNER_REPO.findall(text)
+            if m != slug and m not in OTHER_REPOSITORIES
+        ]
+    assert stale == [], (
+        f"URL names a repository other than {slug}: {stale}. Repoint it, or name the repository in "
+        "OTHER_REPOSITORIES with why it is deliberately not this one"
+    )
 
 
 def test_every_exemption_carries_a_reason() -> None:
     assert all(reason.strip() for reason in EXEMPT.values())
+    assert all(reason.strip() for reason in OTHER_REPOSITORIES.values())
 
 
 def test_every_self_reference_by_slug_names_the_repository_this_clone_is() -> None:


### PR DESCRIPTION
## Summary

This PR performs a selective migration of instruction-layer content from `turboBasic/github-actions` into `github-actions-new`.

## Included

- Restores `CONTRIBUTING.md`, `SECURITY.md`, and `CODE_OF_CONDUCT.md`.
- Adds the three documents to the mechanics layer and maps each in `AGENTS.md`.
- Restores applicable conventions in `docs/ai-instructions.md`, including:
  - composite-action Python modules use only the standard library;
  - those modules remain compatible with older runner interpreters;
  - those modules remain importable by the test suite and type checker;
  - caller `env` does not propagate into called workflows;
  - the repository remains public;
  - the user-level pinning and self-reference caveats.
- Adds `tests/test_action_imports.py` to enforce the standard-library constraint, including reader self-tests.
- Extends the instruction-layer assignment and repository-URL checks for the restored documents and verification harness.
- Moves setup, contribution, security, and conduct guidance to their single authoritative documents.

## Deliberate scope

This PR does not add a rule inventory or reconciliation ledger, new constitution principles, decision records, generic prose-parsing checks, or meta-tests for a new layering framework. Those were proposed during review but are not needed to merge the applicable instruction content.

Where the repositories differ, `github-actions-new` remains authoritative. Content superseded by this tree is not copied.

## Consumer impact

No published capability changes. Inputs, defaults, permissions, check names, and consumer-facing behavior remain unchanged. No consumer ref or ruleset update is required.

## Verification

- `mise run ci`
- 161 tests passed
- lint, schema validation, and strict pyright passed
- composite-action import constraints and instruction-layer assignments are enforced by tests