### PR TITLE
chore: pin shellcheck so actionlint analyses run blocks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,11 @@ git-cliff = "2.14.1"
 "pipx:specify-cli" = "1.0.4"
 prek = "0.5.2"
 python = "3.14"
+# actionlint shells out to shellcheck for every `run:` block when it is on PATH, and skips that
+# analysis without a word when it is not. Most of what this repository executes is shell inside YAML,
+# so an absent pin would leave `mise run lint` and the `actionlint-system` hook both reading less than
+# they appear to.
+shellcheck = "0.11.0"
 taplo = "0.10.0"
 uv = "0.12.10"
 zizmor = "1.30.0"


### PR DESCRIPTION
## What changed

`mise.toml` pins `shellcheck = "0.11.0"`, with the reason beside it.

## Why?

actionlint shells out to shellcheck for every `run:` block when it is on PATH, and skips that analysis
without a word when it is not — so `mise run lint` and the `actionlint-system` hook both read less than
they appear to, and nothing reports the difference. Most of what this repository executes is shell inside
YAML.

`tests/test_tool_versions.py` already refuses a floating `[tools]` entry, so the pin is held from the
moment it exists.

Closes #21

## Blast radius

Nothing a consumer sees. A contributor's next `mise install` picks up one more tool; a `run:` block with
an unquoted expansion now reddens lint where it previously passed.

## Verification

`mise run ci` green. A probe workflow with `name=$1; echo $name` in a `run:` block, planted and then
removed, made `mise run lint` fail with:

```text
shellcheck reported issue in this script: SC2086:info:2:6: Double quote to prevent globbing and word splitting
```

Removing the pin again leaves that probe passing, which is the whole finding.

## Docs

None — no document lists the tool table, and `mise.toml` carries the reason itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)