### PR TITLE
chore: validate action.yml against its published schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,15 @@ repos:
         language: system
         files: ^\.github/ISSUE_TEMPLATE/config\.ya?ml$
 
+      # Both decision units this repository ships are composite actions, read entirely through this
+      # file. GitHub ignores a key it does not recognise here too, so a misspelled `inputs:` entry is
+      # an input that silently does nothing.
+      - id: check-composite-actions
+        name: check-jsonschema (composite actions)
+        entry: uv run check-jsonschema --builtin-schema vendor.github-actions
+        language: system
+        files: ^actions/[^/]+/action\.ya?ml$
+
       # Not a schema: asserts every job sets timeout-minutes.
       - id: check-workflow-timeouts
         name: check-jsonschema (workflow timeouts)

--- a/mise.toml
+++ b/mise.toml
@@ -47,6 +47,7 @@ run = [
   "cspell lint --no-progress .",
   "uv run check-jsonschema --builtin-schema vendor.github-issue-forms .github/ISSUE_TEMPLATE/[0-9]-*.yml",
   "uv run check-jsonschema --builtin-schema vendor.github-issue-config .github/ISSUE_TEMPLATE/config.yml",
+  "uv run check-jsonschema --builtin-schema vendor.github-actions actions/*/action.yml",
   "uv run check-jsonschema --builtin-schema custom.github-workflows-require-timeout .github/workflows/*.yml",
 ]
 


### PR DESCRIPTION
## What changed

A `check-composite-actions` prek hook validates `actions/*/action.yml` with
`--builtin-schema vendor.github-actions`, and the `lint` task runs the same check over the same glob.

## Why?

GitHub accepts an unrecognised key in an action manifest and then ignores it, so a misspelled `inputs:`
entry is an input that silently does nothing — and both decision units this repository ships are
composite actions read entirely through that file. Three `check-jsonschema` hooks already covered the
issue forms, the template config and the workflow timeouts; nothing covered the manifests.

`--builtin-schema` rather than `--schemafile <url>`: a vendored schema needs no network and cannot be
repointed. The actionlint-config schema hook from the same source stays out, for that reason — and a
mis-keyed `.github/actionlint.yaml` already fails safe.

Closes #22

## Blast radius

Nothing a consumer sees. A contributor gets one more hook on `git commit`.

## Verification

`mise run ci` green. Renaming `inputs:` to `input:` in `actions/ruleset-decisions/action.yml` failed both
paths with the same message, then the file was restored:

```text
actions/ruleset-decisions/action.yml::$: Additional properties are not allowed ('input' was unexpected)
```

## Docs

None — `docs/ai-instructions.md` already states the rule this follows ("a new GitHub config file gets a
`check-jsonschema` hook and a matching line in the `lint` task").

🤖 Generated with [Claude Code](https://claude.com/claude-code)