### PR TITLE
chore: render the release notes without spending a runner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,8 @@ One command; it wires up the `pre-commit` and `commit-msg` hooks together.
 ## The loop
 
 ```sh
-mise run ci      # lint, schema validation, typecheck, test — exactly what CI runs
+mise run ci             # lint, schema validation, typecheck, test — exactly what CI runs
+mise run release-notes  # what a release would publish, rendered here, creating nothing
 ```
 
 ## Specs

--- a/mise.toml
+++ b/mise.toml
@@ -58,6 +58,13 @@ run = "uv run pyright"
 description = "Run the test suite"
 run = "uv run pytest"
 
+# Not in `ci`, and not because of the network: it needs a full clone with tags, since the renderer
+# measures the range from the newest version tag and renders an empty one without complaining on a
+# shallow checkout. `mise run ci` has to pass there.
+[tasks.release-notes]
+description = "Render the notes for the unreleased range, offline, creating nothing — needs a full clone with tags"
+run = "git-cliff --config cliff.toml --unreleased"
+
 [tasks.ci]
 description = "Run everything CI runs, locally"
 depends = ["lint", "typecheck", "test"]


### PR DESCRIPTION
## What changed

A `release-notes` mise task renders the unreleased range with the same invocation the release path uses
(`git-cliff --config cliff.toml --unreleased`), creating no tag, ref or release. `CONTRIBUTING.md`'s loop
block names it beside `mise run ci`.

## Why?

The notes are the one artefact this repository publishes, and until now the cheapest look at them was
dispatching a workflow. This is a local render that creates nothing.

It is deliberately absent from what `ci` depends on, and the comment above it says why: the renderer
measures the range from the newest version tag and renders an empty one without complaining on a shallow
checkout, and `mise run ci` has to pass there.

Closes #23

## Blast radius

Nothing — a new local task. No workflow, input or check name moves.

## Verification

`mise run release-notes` rendered the unreleased range from this clone; `git status` and `git tag --list`
were unchanged afterwards. `mise run ci` green.

## Docs

`CONTRIBUTING.md`'s loop block — the one place a contributor reads for what to run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)