### PR TITLE
fix: diff the two rulesets instead of listing which fields moved

### DIFF
--- a/.cspell/project.txt
+++ b/.cspell/project.txt
@@ -35,6 +35,8 @@ zizmorcore
 # GitHub advisory ids and the OpenSSF Scorecard, both named by dependency-review-action's inputs;
 # NOASSERTION is SPDX's own token for a licence a package declares nothing about
 ghsas
+# difflib.unified_diff's parameter for what terminates a rendered line
+lineterm
 NOASSERTION
 OpenSSF
 pyupgrade

--- a/actions/ruleset-decisions/rulesets.py
+++ b/actions/ruleset-decisions/rulesets.py
@@ -1,3 +1,4 @@
+import difflib
 import json
 import os
 import sys
@@ -98,12 +99,17 @@ def normalize(doc: Doc) -> Doc:
 
 
 def render_difference(committed: Doc, live: Doc) -> str:
-    lines = [
-        f"{field}: committed={committed.get(field)!r} live={live.get(field)!r}"
-        for field in sorted(WRITABLE_FIELDS)
-        if committed.get(field) != live.get(field)
-    ]
-    return "\n".join(lines)
+    # A line per differing field put the whole value on that line, so changing one required context
+    # printed both `rules` arrays end to end. This is the last thing read before a write that has no
+    # revert, so it is a diff of the two documents rather than a summary of which fields moved.
+    def rendered(doc: Doc) -> list[str]:
+        projected = {field: doc.get(field) for field in sorted(WRITABLE_FIELDS)}
+        return json.dumps(projected, indent=2, sort_keys=True).splitlines()
+
+    # Live first, so `-` is what GitHub holds now and `+` is what the write would leave.
+    return "\n".join(
+        difflib.unified_diff(rendered(live), rendered(committed), "live", "committed", lineterm="")
+    )
 
 
 def decide(committed: Doc, live: list[Doc]) -> Verdict:

--- a/tests/test_ruleset_decisions.py
+++ b/tests/test_ruleset_decisions.py
@@ -159,7 +159,23 @@ def test_a_real_difference_updates_with_the_difference_rendered_both_sides() -> 
 
 def test_render_difference_names_both_sides_for_every_differing_field() -> None:
     difference = render_difference(normalize(COMMITTED), normalize(_detail(target="tag")))
-    assert "target: committed='branch' live='tag'" in difference
+    assert '-  "target": "tag"' in difference
+    assert '+  "target": "branch"' in difference
+
+
+def test_render_difference_is_empty_when_the_two_documents_agree() -> None:
+    same = normalize(_detail())
+    assert render_difference(same, same) == ""
+
+
+def test_render_difference_keeps_a_nested_change_to_the_line_it_happened_on() -> None:
+    # The failure this replaces: one changed context printed both `rules` arrays on a single line,
+    # leaving the reader to diff them by eye before an irreversible write.
+    live = normalize(_detail())
+    committed = normalize(COMMITTED)
+    difference = render_difference(committed, live)
+    changed = [line for line in difference.splitlines() if line[:1] in {"-", "+"}]
+    assert all(len(line) < 200 for line in changed), difference
 
 
 def test_normalize_drops_everything_but_the_six_writable_fields() -> None:


### PR DESCRIPTION
## What changed

- fix: diff the two rulesets instead of listing which fields moved

## Why?

`render_difference` printed one line per differing field, carrying the whole value on that line. A
change to a single required status check therefore printed both `rules` arrays end to end, leaving
whoever dispatched the apply to compare two long JSON blobs by eye.

That output is the last thing read before a write that has no revert, so unreadable is the defect
rather than a nitpick. Addresses the first finding in #16 — the other three findings there stay open.

## Blast radius

Nothing — internal surface. `ruleset-decisions` is `published = false` in the surface fixture, composes
no check name, and its inputs are named by nothing outside this repository. No workflow input,
permission or check name moves.

## Verification

`mise run ci` green: 165 passed, pyright and every linter clean.

Rendered a real difference against the committed ruleset with `enforcement` changed and the `deletion`
rule removed, and read the output:

```text
--- live
+++ committed
@@ -14,9 +14,12 @@
       ]
     }
   },
-  "enforcement": "evaluate",
+  "enforcement": "active",
   "name": "protect-default-branch",
   "rules": [
+    {
+      "type": "deletion"
+    },
```

Three tests replace the one that pinned the old string format: both sides appear with their diff
markers, an agreeing pair renders empty, and no changed line exceeds 200 characters — the last being
the one that would have failed before this change.

## Docs

None — no document describes this function's output shape. The reason it is a diff rather than a field
summary is a comment beside it.

## Commits

- fix: diff the two rulesets instead of listing which fields moved

  One line per differing field carried the whole value on that line, so a change
  to a single required context printed both `rules` arrays end to end and left the
  reader to compare them by eye. This output is the last thing read before a write
  that has no revert.

  `difflib.unified_diff` over the two projected documents, live first, so `-` is
  what GitHub holds and `+` is what the write would leave.

  Addresses the first finding in #16.

