### PR TITLE
feat: decide what the default branch requires and manage the tag ruleset

### DIFF
--- a/.github/rulesets/immutable-release-tags.json
+++ b/.github/rulesets/immutable-release-tags.json
@@ -1,0 +1,22 @@
+{
+  "name": "immutable release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/tags/v*.*.*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "update"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rulesets/protect-default-branch.json
+++ b/.github/rulesets/protect-default-branch.json
@@ -21,19 +21,37 @@
       "type": "required_linear_history"
     },
     {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": [
+          "squash"
+        ],
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_extra_approval_for_unattributed_changes": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": true,
+        "required_reviewers": []
+      }
+    },
+    {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": false,
+        "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "ci / python-ci"
+            "context": "ci / python-ci",
+            "integration_id": 15368
           },
           {
-            "context": "commits / pr-title"
+            "context": "commits / pr-title",
+            "integration_id": 15368
           },
           {
-            "context": "commits / commit-messages"
+            "context": "commits / commit-messages",
+            "integration_id": 15368
           }
         ]
       }
@@ -43,7 +61,7 @@
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     }
   ]
 }

--- a/actions/ruleset-decisions/rulesets.py
+++ b/actions/ruleset-decisions/rulesets.py
@@ -12,6 +12,10 @@ WRITABLE_FIELDS = frozenset(
     {"name", "target", "enforcement", "conditions", "rules", "bypass_actors"}
 )
 
+# A branch ruleset gates what may reach a ref; a tag one protects the ref itself. Nothing else is
+# managed from the tree, so anything else is a mistake rather than a shape to support.
+TARGETS = frozenset({"branch", "tag"})
+
 NOTHING = "nothing"
 CREATE = "create"
 UPDATE = "update"
@@ -36,15 +40,24 @@ def shape_problem(committed: Doc) -> str | None:
     missing = sorted(WRITABLE_FIELDS - set(committed))
     if missing:
         return f"the committed ruleset omits {missing}, which a write requires"
-    if committed.get("target") != "branch":
-        return f"the committed ruleset's target is {committed.get('target')!r}; only 'branch' is in scope"
+    target = committed.get("target")
+    if target not in TARGETS:
+        return f"the committed ruleset's target is {target!r}; only {sorted(TARGETS)} are in scope"
     rules = cast(list[Doc], committed["rules"])
     rule_types = [str(rule.get("type")) for rule in rules]
+    if not rules:
+        return (
+            "the committed ruleset carries no rules, and a ruleset requiring nothing gates nothing"
+        )
+    # Only a branch ruleset gates on checks. A tag one protects the ref itself, so demanding a
+    # status-checks rule there would refuse the very shape that makes a release tag immutable.
+    if target != "branch":
+        return None
     checks_rules = [rule for rule in rules if rule.get("type") == "required_status_checks"]
     if len(checks_rules) != 1:
         return (
             f"the committed ruleset's rule types are {rule_types}, and exactly one must be "
-            "'required_status_checks' — a ruleset requiring nothing gates nothing"
+            "'required_status_checks' — a branch ruleset requiring nothing gates nothing"
         )
     contexts = cast(
         list[Doc], checks_rules[0].get("parameters", {}).get("required_status_checks", [])

--- a/tests/test_ruleset_decisions.py
+++ b/tests/test_ruleset_decisions.py
@@ -61,10 +61,28 @@ def test_shape_problem_names_a_missing_field() -> None:
     assert "bypass_actors" in message
 
 
-def test_shape_problem_names_a_target_that_is_not_branch() -> None:
-    message = shape_problem({**COMMITTED, "target": "tag"})
+def test_shape_problem_names_a_target_it_does_not_manage() -> None:
+    message = shape_problem({**COMMITTED, "target": "push"})
     assert message is not None
-    assert "'tag'" in message
+    assert "'push'" in message
+
+
+def test_a_tag_ruleset_needs_no_required_status_checks_rule() -> None:
+    # A tag ruleset protects the ref itself. Demanding a checks rule would refuse the only shape that
+    # makes a released version immutable.
+    tag_ruleset: Doc = {
+        **COMMITTED,
+        "target": "tag",
+        "rules": [{"type": "deletion"}, {"type": "update"}],
+    }
+    assert shape_problem(tag_ruleset) is None
+
+
+def test_shape_problem_refuses_a_ruleset_carrying_no_rules_whatever_its_target() -> None:
+    for target in ("branch", "tag"):
+        message = shape_problem({**COMMITTED, "target": target, "rules": []})
+        assert message is not None, target
+        assert "gates nothing" in message
 
 
 def test_shape_problem_names_the_absent_required_status_checks_rule() -> None:
@@ -89,10 +107,10 @@ def test_shape_problem_is_none_for_a_well_formed_ruleset() -> None:
 
 
 def test_a_malformed_committed_file_refuses_before_any_live_ruleset_is_read() -> None:
-    bad = {**COMMITTED, "target": "tag"}
+    bad = {**COMMITTED, "target": "push"}
     verdict = decide(bad, [])
     assert verdict.verdict == REFUSE
-    assert "tag" in verdict.message
+    assert "push" in verdict.message
 
 
 def test_no_matching_name_creates() -> None:


### PR DESCRIPTION
## What changed

- feat: decide what the default branch requires
- feat: manage the release-tag ruleset in the tree

## Why?

Two gaps between what the tree declares about GitHub's rules and what GitHub actually enforces, both of
which would have been resolved *by the cutover* in the wrong direction.

**The committed default-branch ruleset was weaker than the live one.** It carried no `pull_request`
rule while the destination repository enforces one, so dispatching `apply-ruleset` after the rename
would have computed an `update` and stripped the pull-request requirement as a side effect. It also
omitted `integration_id` on the three required contexts, which live holds — so the comparison reported a
difference that was not there, and applying would have unpinned the app, after which any source
reporting that context name satisfies the gate.

**A second live ruleset was invisible.** `immutable release tags` protects `refs/tags/v*.*.*` against
deletion and update and bypasses nobody, not even an administrator. It is what makes ADR 0001's refusal
to delete a published tag enforced rather than merely stated — and neither the applier nor its scheduled
drift read could see it, because it is not in the tree.

Closes #15. The three properties #15 asked to be decided on merit are decided in the first commit's
message, each with what it costs.

## Blast radius

Nothing for a consumer — no capability, input, permission or check name moves.

For this repository, after the ruleset is next applied: a change must arrive as a pull request, a branch
must be current before it merges, and an administrator no longer bypasses a direct push. The cutover's
own unrelated-history push happens *before* that apply, so it is unaffected; a later force-push would
need `bypass_mode` widened by hand first.

## Verification

`mise run ci` green: 167 passed, every linter clean.

`shape_problem` gained three tests — a tag ruleset needs no status-checks rule, a target that is not
managed is named in the refusal, and an empty rule list is refused whatever the target. One existing
test used `target: "tag"` as its malformed example and now uses `push`, since `tag` is valid.

Not verified here, deliberately: the live apply. That is a dispatch on the destination and belongs to the
cutover, where the dry run prints the difference before anything is written.

## Docs

None. `AGENTS.md` already says `.github/rulesets/` answers what the default branch requires; the
reasoning per property is in the commit messages, and the shape rule is owned by `shape_problem` and its
tests.

## Commits

- feat: decide what the default branch requires

  `002-ruleset-in-tree` froze the committed file to reproduce the live ruleset
  field for field, so a block could be attributed to the move or to a content
  change but never both. Three properties were therefore inherited from whatever
  the settings UI held, and none was chosen. Each is now decided.

  **A pull request is required.** The destination repository already enforces this
  and the committed file did not, so applying it as it stood would have stripped
  the requirement as a side effect of a rename. Its parameters are the live ones:
  squash only, no approvals demanded — a sole maintainer cannot approve their own
  pull request, so any positive count blocks every change — and review threads
  resolved before merge, which costs nothing and closes the merged-with-an-open-
  question case.

  **A branch must be current before it merges.** `strict` was false, so two
  individually green changes could land minutes apart and conflict semantically on
  the default branch. That is not hypothetical here: a job renamed in one change
  and a required context edited in another are each green alone, and
  `test_ruleset_contexts.py` only sees the breakage once both are in the tree.

  **An administrator no longer bypasses a direct push.** `always` let a stray
  force-push to the default branch succeed silently. `pull_request` keeps the
  escape hatch where it is used deliberately and withdraws it from the accident.
  The cutover's own unrelated-history push happens before this ruleset is applied,
  so it is unaffected; a later one would need the mode widened by hand first.

  The required contexts also carry `integration_id`, which live holds and the
  committed file omitted. Without it the comparison reports a difference that is
  not there, and applying would unpin the app — after which any source reporting
  that context name satisfies the gate.

  Closes #15.

- feat: manage the release-tag ruleset in the tree

  The destination repository enforces a second ruleset that nothing here knows
  about: `immutable release tags` over `refs/tags/v*.*.*`, refusing deletion and
  update, bypassing nobody — not even an administrator. It is what makes ADR 0001's
  refusal to delete a published tag enforced rather than merely stated, and it was
  invisible to both the applier and its scheduled drift read.

  `shape_problem` refused it on two counts, so it is scoped by target first. Only a
  branch ruleset gates on checks; a tag one protects the ref itself, and demanding a
  status-checks rule there would refuse the only shape that makes a release
  immutable. The rule-requiring guard that demand carried is kept for both targets
  as an empty-rules check, so neither target can declare a ruleset that gates
  nothing.

  The file stem and the ruleset's own name differ — `immutable-release-tags.json`
  against `immutable release tags` — because the live name is what a write matches
  on, and renaming it would create a second ruleset rather than update this one.

