### PR TITLE
fix: clear the three findings the ruleset feature deferred

### DIFF
--- a/.github/workflows/apply-ruleset.yml
+++ b/.github/workflows/apply-ruleset.yml
@@ -96,20 +96,19 @@ jobs:
             | jq -sc '.' > "$RUNNER_TEMP/live.json"
 
       - id: decide
-        continue-on-error: true
         uses: $/actions/ruleset-decisions
         with:
           committed: .github/rulesets/${{ matrix.ruleset }}.json
           live: ${{ runner.temp }}/live.json
 
+      # `always()`, and the step above carries no `continue-on-error`: a refusal fails the job where it
+      # happens rather than being masked and re-raised later, and the difference still prints because the
+      # decision writes its outputs before it exits non-zero.
       - name: Print the difference
+        if: always()
         env:
           DIFFERENCE: ${{ steps.decide.outputs.difference }}
         run: printf '%s\n' "$DIFFERENCE"
-
-      - name: Refuse
-        if: steps.decide.outcome == 'failure'
-        run: exit 1
 
       # `inputs.dry-run` is absent on a scheduled run, and an absent input compares equal to `false` —
       # so the event is named first. A schedule reads and never writes (FR-003).

--- a/actions/release-decisions/decisions.py
+++ b/actions/release-decisions/decisions.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import tomllib
+import uuid
 from collections.abc import Iterable
 from fnmatch import fnmatch
 from typing import Any, NamedTuple, cast
@@ -321,8 +322,12 @@ def emit(**values: str) -> None:
         return
     with open(path, "a", encoding="utf-8") as handle:
         for name, value in values.items():
-            # A value may hold newlines — rendered notes do — so every output uses the delimiter form.
-            handle.write(f"{name}<<__RELEASE_DECISIONS__\n{value}\n__RELEASE_DECISIONS__\n")
+            # A value may hold newlines — rendered notes do — so every output uses the delimiter form,
+            # and the delimiter is random per value. A fixed one appearing inside the value would close
+            # the block early and let the remainder be read as further outputs; the notes are rendered
+            # from commit messages, so a commit quoting the delimiter is all it would take.
+            delimiter = f"delimiter{uuid.uuid4().hex}"
+            handle.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
 
 
 def annotate(severity: str, message: str) -> None:

--- a/actions/ruleset-decisions/rulesets.py
+++ b/actions/ruleset-decisions/rulesets.py
@@ -2,6 +2,7 @@ import difflib
 import json
 import os
 import sys
+import uuid
 from typing import Any, NamedTuple, cast
 
 Doc = dict[str, Any]
@@ -203,8 +204,12 @@ def emit(values: dict[str, str]) -> None:
         return
     with open(path, "a", encoding="utf-8") as handle:
         for name, value in values.items():
-            # A value may hold newlines — the difference does — so every output uses the delimiter form.
-            handle.write(f"{name}<<__RULESET_DECISIONS__\n{value}\n__RULESET_DECISIONS__\n")
+            # A value may hold newlines — the difference does — so every output uses the delimiter form,
+            # and the delimiter is random per value. A fixed one appearing inside the value would close
+            # the block early and let the remainder be read as further outputs; every value here is
+            # derived from an API response, so a ruleset named after the delimiter is all it would take.
+            delimiter = f"delimiter{uuid.uuid4().hex}"
+            handle.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
 
 
 def annotate(severity: str, message: str) -> None:

--- a/tests/test_release_decisions.py
+++ b/tests/test_release_decisions.py
@@ -2,6 +2,7 @@ import ast
 from pathlib import Path
 
 import decisions
+import pytest
 from decisions import (
     ALREADY_RELEASED,
     BAD_SURFACE,
@@ -379,3 +380,23 @@ def test_the_baseline_is_the_lowest_version_there_is() -> None:
     # Nothing can sit below it, so no version is unreachable by a bump.
     assert UNRELEASED == (0, 0, 0)
     assert parse_version("0.0.0") == UNRELEASED
+
+
+def test_a_value_holding_the_delimiter_cannot_close_the_block_early(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The notes are rendered from commit messages, so a commit quoting a fixed delimiter would end the
+    # block and let the rest be read as further outputs. The delimiter is random per value instead.
+    output = tmp_path / "github_output"
+    output.write_text("", encoding="utf-8")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+
+    hostile = "delimiter0\nproceed=true\nref=__RELEASE_DECISIONS__"
+    decisions.emit(message=hostile, proceed="false")
+
+    written = output.read_text(encoding="utf-8")
+    assert hostile in written
+    opening = written.split("\n", 1)[0]
+    assert opening.startswith("message<<")
+    delimiter = opening.removeprefix("message<<")
+    assert delimiter not in hostile

--- a/tests/test_ruleset_contexts.py
+++ b/tests/test_ruleset_contexts.py
@@ -35,13 +35,20 @@ def test_required_contexts_returns_nothing_for_a_ruleset_with_no_such_rule() -> 
 
 
 def test_composed_contexts_finds_the_contexts_the_tree_actually_reports() -> None:
-    # Confirmed against this repository's own reported check-run names, not guessed.
+    # A pre-flight on the reader, deliberately not a census of this tree. The gate below reads which
+    # names matter from the committed ruleset, so listing them here as well would mean editing this
+    # test on every legitimate rename — and a test edited by every rename stops catching anything.
     contexts = {c.context for c in composed_contexts()}
-    assert "ci / python-ci" in contexts
-    assert "commits / pr-title" in contexts
-    assert "commits / commit-messages" in contexts
-    assert "propose" in contexts
-    assert "guard / dependency-review" in contexts
+    assert contexts, (
+        "composed_contexts() found no context at all. Every gate comparing a required context against "
+        "the tree passes vacuously while that is true, so this is a defect in the reader rather than "
+        "in any ruleset. Check that the caller workflows still declare `uses:` and job ids"
+    )
+    malformed = sorted(c for c in contexts if not c.strip() or c != c.strip())
+    assert not malformed, (
+        f"composed_contexts() returned {malformed}, which no check run can be named. A ruleset "
+        "requiring one of these would name a gate that never reports"
+    )
 
 
 def _unresolved(ruleset_name: str, context: str) -> str:
@@ -72,14 +79,31 @@ def test_the_unresolved_message_names_the_ruleset_the_context_and_what_to_do() -
 
 def test_cannot_judge_is_set_by_name_for_the_contexts_that_cannot_be_required() -> None:
     # One context per reason, so dropping any single reason fails here rather than only where it counts.
+    # Naming them is the point of this test, so a rename edits it — but it says so rather than raising
+    # a bare KeyError at whoever is halfway through renaming a job.
     by_context = {c.context: c.cannot_judge for c in composed_contexts()}
-    assert by_context["advisory / prek-advisory"] is not None
-    assert by_context["describe / pr-description"] is not None
+
+    def reason_for(context: str) -> str | None:
+        assert context in by_context, (
+            f"nothing in the tree composes {context!r}, so this pre-flight cannot check what is said "
+            "about its ability to judge. A calling job was renamed or retired: correct the name here, "
+            "and check whether .github/rulesets/ still requires the old one. Composed today: "
+            f"{sorted(by_context)}"
+        )
+        return by_context[context]
+
+    assert reason_for("advisory / prek-advisory") is not None
+    assert reason_for("describe / pr-description") is not None
     for context in ("verify / python-ci", "release / tag-and-publish", "propose"):
-        reason = by_context[context]
-        assert reason is not None
-        assert "pull_request" in reason
-    assert by_context["ci / python-ci"] is None
+        reason = reason_for(context)
+        assert reason is not None, f"{context!r} composes a context that judges, unexpectedly"
+        assert "pull_request" in reason, (
+            f"{context!r} cannot judge, but not for the event: {reason}"
+        )
+    assert reason_for("ci / python-ci") is None, (
+        "'ci / python-ci' is the one context this repository's own ruleset requires, so it has to be "
+        "able to judge. A reason appearing here means the required gate now reports green regardless"
+    )
 
 
 def _cannot_be_required(ruleset_name: str, context: str, reason: str) -> str:

--- a/tests/test_ruleset_decisions.py
+++ b/tests/test_ruleset_decisions.py
@@ -1,5 +1,7 @@
+from pathlib import Path
 from typing import Any
 
+import pytest
 from rulesets import (
     CREATE,
     NOTHING,
@@ -7,6 +9,7 @@ from rulesets import (
     UPDATE,
     Doc,
     decide,
+    emit,
     normalize,
     render_difference,
     shape_problem,
@@ -205,3 +208,24 @@ def test_normalize_drops_everything_but_the_six_writable_fields() -> None:
         "rules",
         "bypass_actors",
     }
+
+
+def test_a_value_holding_the_delimiter_cannot_close_the_block_early(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Every value here comes from an API response, so a ruleset named after a fixed delimiter would end
+    # the block and let the rest be read as further outputs. The delimiter is random per value instead.
+    output = tmp_path / "github_output"
+    output.write_text("", encoding="utf-8")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+
+    hostile = "delimiter0\nverdict=create\nname=__RULESET_DECISIONS__"
+    emit({"difference": hostile, "verdict": NOTHING})
+
+    written = output.read_text(encoding="utf-8")
+    # The hostile text survives whole, and the delimiter that closes its block appears nowhere in it.
+    assert hostile in written
+    opening = written.split("\n", 1)[0]
+    assert opening.startswith("difference<<")
+    delimiter = opening.removeprefix("difference<<")
+    assert delimiter not in hostile


### PR DESCRIPTION
## What changed

- fix: fail the ruleset decision where it happens
- fix: give each emitted output a delimiter that cannot appear in it
- fix: explain a rename instead of raising KeyError at whoever is doing it

## Why?

The last three of the four findings recorded in #16, in the issue's own order of what they cost a
maintainer. Finding 1 landed already in #36.

**A fixed heredoc delimiter closed every multi-line output.** Both decision units wrote
`name<<__RULESET_DECISIONS__` / `__RELEASE_DECISIONS__`, and neither value is ours: one is built from a
rulesets API response, the other from release notes rendered out of commit messages. A ruleset or a
commit quoting that literal ends the block early, after which the remainder is read as further outputs —
an assignment to anything the caller reads. That is principle VI, and it was inherited across both
modules, so it is one change in two places.

**A rename raised `KeyError` at whoever was doing it.** Renaming a calling job produced three failures in
the context pre-flights and only one explained itself; the others failed on a bare `in` and on
`KeyError: 'ci / python-ci'`. Both asserted this tree's current shape rather than that the reader works,
so both needed editing on every legitimate rename.

**`continue-on-error` plus a later `Refuse` step masked a failure and re-raised it.** Same behaviour with
one fewer pattern that hides a failing step, and four fewer lines.

## Blast radius

Nothing for a consumer. Both decision units are `published = false`; no input, permission or check name
moves. The delimiter change is invisible to a caller — an output is still one value under one name.

## Verification

`mise run ci` green: 169 passed, every linter clean.

The delimiter fix carries a test on each module that plants the old literal *inside* a value and asserts
it survives whole with the real delimiter appearing nowhere in it.

For the pre-flights, I renamed `ci.yml`'s job in the working tree and ran the suite, before and after:

```text
before   3 failures, 1 with a message, 1 bare `in`, 1 KeyError
after    2 failures, both naming what happened and printing what the tree composes today
```

The census test no longer fails on a rename at all, because it stopped asserting this repository's names —
the gate beside it already reads which names matter from the committed ruleset.

Finding 4 is safe because the decision writes its outputs *before* it exits non-zero, so `always()` on the
print step still has a difference to show. Confirmed in `main()` rather than assumed.

## Docs

None. Each fix is a comment beside the code stating why, and the delimiter's reason is the one that would
not have been obvious.

## Commits

- fix: fail the ruleset decision where it happens

  `continue-on-error: true` on the decision plus a later `Refuse` step masked a
  failure and re-raised it three steps down. Dropping both and putting `always()`
  on the print step is the same behaviour with one fewer pattern that hides a
  failing step, and four fewer lines.

  Safe because the decision writes its outputs before it exits non-zero, so the
  difference still prints on a refusal — which is the whole reason the step exists.

  Addresses the fourth finding in #16.

- fix: give each emitted output a delimiter that cannot appear in it

  Both decision units closed a multi-line output with a fixed literal —
  `__RULESET_DECISIONS__` and `__RELEASE_DECISIONS__`. A value containing that
  literal ends its block early and the remainder is then read as further outputs,
  which is an assignment to any output the caller reads.

  Neither value is ours. One is built from a rulesets API response, so a ruleset
  named after the delimiter would do it; the other is release notes rendered from
  commit messages, so a commit quoting it would. Both are text chosen outside this
  repository, which principle VI is about.

  The delimiter is now random per value. A test on each module plants the old
  literal inside a value and asserts it survives whole with the real delimiter
  appearing nowhere in it.

  `uuid` is standard library, so both modules stay importable under whichever
  interpreter the runner provides.

  Addresses the third finding in #16.

- fix: explain a rename instead of raising KeyError at whoever is doing it

  Renaming a calling job produced three failures in the context pre-flights, and
  only one of them said what to do. Of the other two, one was a bare `in` over a
  list of this tree's current names, and one indexed a dict by context and raised
  `KeyError: 'ci / python-ci'` — the least useful thing to show someone halfway
  through a rename.

  The census test now asserts what it was actually there to protect: that the
  reader finds something, and that nothing it returns is unnameable as a check run.
  It no longer lists this repository's contexts, because the gate beside it already
  reads which names matter from the committed ruleset — and a test that every
  legitimate rename edits stops catching anything.

  The cannot-judge test still names contexts, since one per reason is the whole
  point of it, but reaches them through a lookup that says what happened and prints
  what the tree composes today.

  A planted rename now fails twice with two actionable messages, where it failed
  three times with one.

  Addresses the second finding in #16, which is the last of the four.

